### PR TITLE
Provide Sessions with Inference Model Persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ RAG Studio requires AWS for access to both LLM and embedding models. Please comp
 
 - A S3 bucket to store the documents
 - The following models configured and accessible via AWS Bedrock. Any of the models not enabled will not function in the UI.
-  - Llama3.1 8b Instruct V1 (`meta.llama3-1-8b-instruct-v1:0`) - This model is required for the RAG Studio to function
-  - Llama3.1 70b Instruct V1 (`meta.llama3-1-70b-instruct-v1:0`)
+  - Llama3.1 8b Instruct v1 (`meta.llama3-1-8b-instruct-v1:0`) - This model is required for the RAG Studio to function
+  - Llama3.1 70b Instruct v1 (`meta.llama3-1-70b-instruct-v1:0`)
+  - Cohere Command R+ v1 (`cohere.command-r-plus-v1:0`)
 - For Embedding, you will need to enable the following model in AWS Bedrock:
   - Cohere English Embedding v3 (`meta.cohere-english-embedding-v3:0`)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ RAG Studio requires AWS for access to both LLM and embedding models. Please comp
 - The following models configured and accessible via AWS Bedrock. Any of the models not enabled will not function in the UI.
   - Llama3.1 8b Instruct V1 (`meta.llama3-1-8b-instruct-v1:0`) - This model is required for the RAG Studio to function
   - Llama3.1 70b Instruct V1 (`meta.llama3-1-70b-instruct-v1:0`)
-  - Llama3.1 405b Instruct V1 (`meta.llama3-1-405b-instruct-v1:0`)
 - For Embedding, you will need to enable the following model in AWS Bedrock:
   - Cohere English Embedding v3 (`meta.cohere-english-embedding-v3:0`)
 

--- a/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionController.java
+++ b/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionController.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * CLOUDERA APPLIED MACHINE LEARNING PROTOTYPE (AMP)
  * (C) Cloudera, Inc. 2024
  * All rights reserved.
@@ -61,6 +61,13 @@ public class SessionController {
     String username = userTokenCookieDecoder.extractUsername(request.getCookies());
     input = input.withCreatedById(username).withUpdatedById(username);
     return sessionService.create(input);
+  }
+
+  @PostMapping(path = "/{id}", consumes = "application/json", produces = "application/json")
+  public Types.Session update(@RequestBody Types.Session input, HttpServletRequest request) {
+    String username = userTokenCookieDecoder.extractUsername(request.getCookies());
+    input = input.withUpdatedById(username);
+    return sessionService.update(input);
   }
 
   @DeleteMapping(path = "/{id}")

--- a/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionRepository.java
+++ b/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionRepository.java
@@ -160,8 +160,19 @@ public class SessionRepository {
 
   public void delete(Long id) {
     jdbi.useHandle(
+        handle -> handle.execute("UPDATE CHAT_SESSION SET DELETED = ? WHERE ID = ?", true, id));
+  }
+
+  public void update(Types.Session input) {
+    jdbi.useHandle(
         handle -> {
-          handle.execute("UPDATE CHAT_SESSION SET DELETED = ? WHERE ID = ?", true, id);
+          var sql =
+              """
+            UPDATE CHAT_SESSION
+            SET name = :name, updated_by_id = :updatedById, inference_model = :inferenceModel, response_chunks = :responseChunks
+            WHERE id = :id
+          """;
+          handle.createUpdate(sql).bindMethods(input).execute();
         });
   }
 }

--- a/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionRepository.java
+++ b/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionRepository.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * CLOUDERA APPLIED MACHINE LEARNING PROTOTYPE (AMP)
  * (C) Cloudera, Inc. 2024
  * All rights reserved.
@@ -65,8 +65,8 @@ public class SessionRepository {
         handle -> {
           var sql =
               """
-            INSERT INTO CHAT_SESSION (name, created_by_id, updated_by_id)
-            VALUES (:name, :createdById, :updatedById)
+            INSERT INTO CHAT_SESSION (name, created_by_id, updated_by_id, inference_model, response_chunks)
+            VALUES (:name, :createdById, :updatedById, :inferenceModel, :responseChunks)
           """;
           Long id = insertSession(input, handle, sql);
           insertSessionDataSources(handle, id, input.dataSourceIds());
@@ -123,6 +123,8 @@ public class SessionRepository {
                         Types.Session.builder()
                             .id(sessionId)
                             .name(rowView.getColumn("name", String.class))
+                            .inferenceModel(rowView.getColumn("inference_model", String.class))
+                            .responseChunks(rowView.getColumn("response_chunks", Integer.class))
                             .createdById(rowView.getColumn("created_by_id", String.class))
                             .timeCreated(rowView.getColumn("time_created", Instant.class))
                             .updatedById(rowView.getColumn("updated_by_id", String.class))

--- a/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionService.java
+++ b/backend/src/main/java/com/cloudera/cai/rag/sessions/SessionService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * CLOUDERA APPLIED MACHINE LEARNING PROTOTYPE (AMP)
  * (C) Cloudera, Inc. 2024
  * All rights reserved.
@@ -54,6 +54,11 @@ public class SessionService {
   public Types.Session create(Types.Session input) {
     var id = sessionRepository.create(input);
     return sessionRepository.getSessionById(id);
+  }
+
+  public Types.Session update(Types.Session input) {
+    sessionRepository.update(input);
+    return sessionRepository.getSessionById(input.id());
   }
 
   public List<Types.Session> getSessions() {

--- a/backend/src/main/resources/migrations/h2/13_add_chat_configuration.down.sql
+++ b/backend/src/main/resources/migrations/h2/13_add_chat_configuration.down.sql
@@ -20,7 +20,7 @@
  * with an authorized and properly licensed third party, you do not
  * have any rights to access nor to use this code.
  *
- * Absent a written agreement with Cloudera, Inc. ("Cloudera") to the
+ * Absent a written agreement with Cloudera, Inc. (“Cloudera”) to the
  * contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
  * KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
  * WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
@@ -36,71 +36,11 @@
  * DATA.
  */
 
-package com.cloudera.cai.rag;
+SET MODE MYSQL;
 
-import jakarta.annotation.Nullable;
-import java.time.Instant;
-import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Singular;
-import lombok.With;
+BEGIN;
 
-public class Types {
-  /** Data returned from the file upload endpoint. */
-  public record RagDocumentMetadata(
-      String fileName, String documentId, String extension, long sizeInBytes) {}
+ALTER TABLE CHAT_SESSION DROP COLUMN inference_model;
+ALTER TABLE CHAT_SESSION DROP COLUMN response_chunks;
 
-  /** Data representing the database table for RAG file metadata (llm_project_rag_document) */
-  @Builder(toBuilder = true)
-  public record RagDocument(
-      @With Long id,
-      String filename,
-      Long dataSourceId,
-      String documentId,
-      String s3Path,
-      @With Instant vectorUploadTimestamp,
-      Long sizeInBytes,
-      String extension,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      @With Instant summaryCreationTimestamp) {}
-
-  @Getter
-  public enum ConnectionType {
-    MANUAL,
-    CDF,
-    API,
-    OTHER
-  }
-
-  @With
-  public record RagDataSource(
-      Long id,
-      String name,
-      Integer chunkSize,
-      Integer chunkOverlapPercent,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      ConnectionType connectionType,
-      @Nullable Integer documentCount,
-      @Nullable Long totalDocSize) {}
-
-  @With
-  @Builder
-  public record Session(
-      Long id,
-      String name,
-      @Singular List<Long> dataSourceIds,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      Instant lastInteractionTime,
-      String inferenceModel,
-      Integer responseChunks) {}
-}
+COMMIT;

--- a/backend/src/main/resources/migrations/h2/13_add_chat_configuration.up.sql
+++ b/backend/src/main/resources/migrations/h2/13_add_chat_configuration.up.sql
@@ -20,7 +20,7 @@
  * with an authorized and properly licensed third party, you do not
  * have any rights to access nor to use this code.
  *
- * Absent a written agreement with Cloudera, Inc. ("Cloudera") to the
+ * Absent a written agreement with Cloudera, Inc. (“Cloudera”) to the
  * contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
  * KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
  * WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
@@ -36,71 +36,12 @@
  * DATA.
  */
 
-package com.cloudera.cai.rag;
+SET MODE MYSQL;
 
-import jakarta.annotation.Nullable;
-import java.time.Instant;
-import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Singular;
-import lombok.With;
+BEGIN;
 
-public class Types {
-  /** Data returned from the file upload endpoint. */
-  public record RagDocumentMetadata(
-      String fileName, String documentId, String extension, long sizeInBytes) {}
+ALTER TABLE CHAT_SESSION ADD COLUMN inference_model VARCHAR(255);
+ALTER TABLE CHAT_SESSION ADD COLUMN response_chunks INTEGER DEFAULT 5;
 
-  /** Data representing the database table for RAG file metadata (llm_project_rag_document) */
-  @Builder(toBuilder = true)
-  public record RagDocument(
-      @With Long id,
-      String filename,
-      Long dataSourceId,
-      String documentId,
-      String s3Path,
-      @With Instant vectorUploadTimestamp,
-      Long sizeInBytes,
-      String extension,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      @With Instant summaryCreationTimestamp) {}
 
-  @Getter
-  public enum ConnectionType {
-    MANUAL,
-    CDF,
-    API,
-    OTHER
-  }
-
-  @With
-  public record RagDataSource(
-      Long id,
-      String name,
-      Integer chunkSize,
-      Integer chunkOverlapPercent,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      ConnectionType connectionType,
-      @Nullable Integer documentCount,
-      @Nullable Long totalDocSize) {}
-
-  @With
-  @Builder
-  public record Session(
-      Long id,
-      String name,
-      @Singular List<Long> dataSourceIds,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      Instant lastInteractionTime,
-      String inferenceModel,
-      Integer responseChunks) {}
-}
+COMMIT;

--- a/backend/src/main/resources/migrations/migrations.txt
+++ b/backend/src/main/resources/migrations/migrations.txt
@@ -23,3 +23,5 @@
 11_add_session_deleted.up.sql
 12_add_doc_deleted.down.sql
 12_add_doc_deleted.up.sql
+13_add_chat_configuration.down.sql
+13_add_chat_configuration.up.sql

--- a/backend/src/main/resources/migrations/postgres/13_add_chat_configuration.down.sql
+++ b/backend/src/main/resources/migrations/postgres/13_add_chat_configuration.down.sql
@@ -20,7 +20,7 @@
  * with an authorized and properly licensed third party, you do not
  * have any rights to access nor to use this code.
  *
- * Absent a written agreement with Cloudera, Inc. ("Cloudera") to the
+ * Absent a written agreement with Cloudera, Inc. (“Cloudera”) to the
  * contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
  * KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
  * WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
@@ -36,71 +36,11 @@
  * DATA.
  */
 
-package com.cloudera.cai.rag;
+SET MODE MYSQL;
 
-import jakarta.annotation.Nullable;
-import java.time.Instant;
-import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Singular;
-import lombok.With;
+BEGIN;
 
-public class Types {
-  /** Data returned from the file upload endpoint. */
-  public record RagDocumentMetadata(
-      String fileName, String documentId, String extension, long sizeInBytes) {}
+ALTER TABLE CHAT_SESSION DROP COLUMN inference_model;
+ALTER TABLE CHAT_SESSION DROP COLUMN response_chunks;
 
-  /** Data representing the database table for RAG file metadata (llm_project_rag_document) */
-  @Builder(toBuilder = true)
-  public record RagDocument(
-      @With Long id,
-      String filename,
-      Long dataSourceId,
-      String documentId,
-      String s3Path,
-      @With Instant vectorUploadTimestamp,
-      Long sizeInBytes,
-      String extension,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      @With Instant summaryCreationTimestamp) {}
-
-  @Getter
-  public enum ConnectionType {
-    MANUAL,
-    CDF,
-    API,
-    OTHER
-  }
-
-  @With
-  public record RagDataSource(
-      Long id,
-      String name,
-      Integer chunkSize,
-      Integer chunkOverlapPercent,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      ConnectionType connectionType,
-      @Nullable Integer documentCount,
-      @Nullable Long totalDocSize) {}
-
-  @With
-  @Builder
-  public record Session(
-      Long id,
-      String name,
-      @Singular List<Long> dataSourceIds,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      Instant lastInteractionTime,
-      String inferenceModel,
-      Integer responseChunks) {}
-}
+COMMIT;

--- a/backend/src/main/resources/migrations/postgres/13_add_chat_configuration.up.sql
+++ b/backend/src/main/resources/migrations/postgres/13_add_chat_configuration.up.sql
@@ -20,7 +20,7 @@
  * with an authorized and properly licensed third party, you do not
  * have any rights to access nor to use this code.
  *
- * Absent a written agreement with Cloudera, Inc. ("Cloudera") to the
+ * Absent a written agreement with Cloudera, Inc. (“Cloudera”) to the
  * contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
  * KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
  * WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
@@ -36,71 +36,12 @@
  * DATA.
  */
 
-package com.cloudera.cai.rag;
+SET MODE MYSQL;
 
-import jakarta.annotation.Nullable;
-import java.time.Instant;
-import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Singular;
-import lombok.With;
+BEGIN;
 
-public class Types {
-  /** Data returned from the file upload endpoint. */
-  public record RagDocumentMetadata(
-      String fileName, String documentId, String extension, long sizeInBytes) {}
+ALTER TABLE CHAT_SESSION ADD COLUMN inference_model VARCHAR(255);
+ALTER TABLE CHAT_SESSION ADD COLUMN response_chunks INTEGER DEFAULT 5;
 
-  /** Data representing the database table for RAG file metadata (llm_project_rag_document) */
-  @Builder(toBuilder = true)
-  public record RagDocument(
-      @With Long id,
-      String filename,
-      Long dataSourceId,
-      String documentId,
-      String s3Path,
-      @With Instant vectorUploadTimestamp,
-      Long sizeInBytes,
-      String extension,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      @With Instant summaryCreationTimestamp) {}
 
-  @Getter
-  public enum ConnectionType {
-    MANUAL,
-    CDF,
-    API,
-    OTHER
-  }
-
-  @With
-  public record RagDataSource(
-      Long id,
-      String name,
-      Integer chunkSize,
-      Integer chunkOverlapPercent,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      ConnectionType connectionType,
-      @Nullable Integer documentCount,
-      @Nullable Long totalDocSize) {}
-
-  @With
-  @Builder
-  public record Session(
-      Long id,
-      String name,
-      @Singular List<Long> dataSourceIds,
-      Instant timeCreated,
-      Instant timeUpdated,
-      String createdById,
-      String updatedById,
-      Instant lastInteractionTime,
-      String inferenceModel,
-      Integer responseChunks) {}
-}
+COMMIT;

--- a/backend/src/test/java/com/cloudera/cai/rag/TestData.java
+++ b/backend/src/test/java/com/cloudera/cai/rag/TestData.java
@@ -45,7 +45,8 @@ import java.util.List;
 
 public class TestData {
   public static Types.Session createTestSessionInstance(String sessionName) {
-    return new Types.Session(null, sessionName, List.of(1L, 2L, 3L), null, null, null, null, null);
+    return new Types.Session(
+        null, sessionName, List.of(1L, 2L, 3L), null, null, null, null, null, "test-model", 3);
   }
 
   public static Types.RagDataSource createTestDataSourceInstance(

--- a/backend/src/test/java/com/cloudera/cai/rag/sessions/SessionControllerTest.java
+++ b/backend/src/test/java/com/cloudera/cai/rag/sessions/SessionControllerTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * CLOUDERA APPLIED MACHINE LEARNING PROTOTYPE (AMP)
  * (C) Cloudera, Inc. 2024
  * All rights reserved.
@@ -62,6 +62,8 @@ class SessionControllerTest {
     Types.Session result = sessionController.create(input, request);
     assertThat(result.id()).isNotNull();
     assertThat(result.name()).isEqualTo(sessionName);
+    assertThat(result.inferenceModel()).isEqualTo(input.inferenceModel());
+    assertThat(result.responseChunks()).isEqualTo(input.responseChunks());
     assertThat(result.dataSourceIds()).containsExactlyInAnyOrder(1L, 2L, 3L);
     assertThat(result.timeCreated()).isNotNull();
     assertThat(result.timeUpdated()).isNotNull();

--- a/backend/src/test/java/com/cloudera/cai/rag/sessions/SessionControllerTest.java
+++ b/backend/src/test/java/com/cloudera/cai/rag/sessions/SessionControllerTest.java
@@ -73,6 +73,45 @@ class SessionControllerTest {
   }
 
   @Test
+  void update() throws JsonProcessingException {
+    SessionController sessionController = new SessionController(SessionService.createNull());
+    var request = new MockHttpServletRequest();
+    request.setCookies(
+        new MockCookie("_basusertoken", UserTokenCookieDecoderTest.encodeCookie("test-user")));
+    var sessionName = "test";
+    Types.Session input = TestData.createTestSessionInstance(sessionName);
+    Types.Session result = sessionController.create(input, request);
+
+    var updatedResponseChunks = 1;
+    var updatedInferenceModel = "new-model-name";
+    var updatedName = "new-name";
+
+    request = new MockHttpServletRequest();
+    request.setCookies(
+        new MockCookie(
+            "_basusertoken", UserTokenCookieDecoderTest.encodeCookie("update-test-user")));
+
+    var updatedSession =
+        sessionController.update(
+            result
+                .withInferenceModel(updatedInferenceModel)
+                .withResponseChunks(updatedResponseChunks)
+                .withName(updatedName),
+            request);
+
+    assertThat(updatedSession.id()).isNotNull();
+    assertThat(updatedSession.name()).isEqualTo(updatedName);
+    assertThat(updatedSession.inferenceModel()).isEqualTo(updatedInferenceModel);
+    assertThat(updatedSession.responseChunks()).isEqualTo(updatedResponseChunks);
+    assertThat(updatedSession.dataSourceIds()).containsExactlyInAnyOrder(1L, 2L, 3L);
+    assertThat(updatedSession.timeCreated()).isNotNull();
+    assertThat(updatedSession.timeUpdated()).isNotNull();
+    assertThat(updatedSession.createdById()).isEqualTo("test-user");
+    assertThat(updatedSession.updatedById()).isEqualTo("update-test-user");
+    assertThat(updatedSession.lastInteractionTime()).isNull();
+  }
+
+  @Test
   void delete() {
     SessionService sessionService = SessionService.createNull();
     SessionController sessionController = new SessionController(sessionService);

--- a/llm-service/app/rag_types.py
+++ b/llm-service/app/rag_types.py
@@ -40,10 +40,13 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 
+from app.services.models import DEFAULT_BEDROCK_LLM_MODEL
+
+
 class RagPredictConfiguration(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     top_k: int = 5
     chunk_size: int = 512
-    model_name: str = "meta.llama3-1-8b-instruct-v1:0"
+    model_name: str = DEFAULT_BEDROCK_LLM_MODEL
     exclude_knowledge_base: Optional[bool] = False

--- a/llm-service/app/services/doc_summaries.py
+++ b/llm-service/app/services/doc_summaries.py
@@ -115,7 +115,7 @@ def generate_summary(
 
 ## todo: move to somewhere better; these are defaults to use when none are explicitly provided
 def set_settings_globals() -> None:
-    Settings.llm = models.get_llm("meta.llama3-8b-instruct-v1:0")
+    Settings.llm = models.get_llm()
     Settings.embed_model = models.get_embedding_model()
     Settings.text_splitter = SentenceSplitter(chunk_size=1024)
 

--- a/llm-service/app/services/evaluators.py
+++ b/llm-service/app/services/evaluators.py
@@ -47,7 +47,7 @@ def evaluate_response(
         query: str,
         chat_response: AgentChatResponse,
 ) -> tuple[float, float]:
-    evaluator_llm = models.get_llm("meta.llama3-8b-instruct-v1:0")
+    evaluator_llm = models.get_llm()
 
     relevancy_evaluator = RelevancyEvaluator(llm=evaluator_llm)
     relevance = relevancy_evaluator.evaluate_response(

--- a/llm-service/app/services/models.py
+++ b/llm-service/app/services/models.py
@@ -51,6 +51,7 @@ from .caii import get_embedding_model as caii_embedding
 from .caii import get_llm as caii_llm
 from .llama_utils import completion_to_prompt, messages_to_prompt
 
+DEFAULT_BEDROCK_LLM_MODEL = "meta.llama3-1-8b-instruct-v1:0"
 
 def get_embedding_model() -> BaseEmbedding:
     if is_caii_enabled():
@@ -58,7 +59,7 @@ def get_embedding_model() -> BaseEmbedding:
     return BedrockEmbedding(model_name="cohere.embed-english-v3")
 
 
-def get_llm(model_name: str = None) -> LLM:
+def get_llm(model_name: str = DEFAULT_BEDROCK_LLM_MODEL) -> LLM:
     if is_caii_enabled():
         return caii_llm(
             domain=os.environ["CAII_DOMAIN"],
@@ -90,20 +91,15 @@ def is_caii_enabled() -> bool:
     domain: str = os.environ.get("CAII_DOMAIN", "")
     return len(domain) > 0
 
-
 def _get_bedrock_llm_models() -> List[Dict[str, Any]]:
     return [
         {
-            "model_id": "meta.llama3-1-8b-instruct-v1:0",
+            "model_id": DEFAULT_BEDROCK_LLM_MODEL,
             "name": "Llama3.1 8B Instruct v1",
         },
         {
             "model_id": "meta.llama3-1-70b-instruct-v1:0",
             "name": "Llama3.1 70B Instruct v1",
-        },
-        {
-            "model_id": "meta.llama3-1-405b-instruct-v1:0",
-            "name": "Llama3.1 405B Instruct v1",
         },
         {
             "model_id": "cohere.command-r-plus-v1:0",

--- a/llm-service/app/services/models.py
+++ b/llm-service/app/services/models.py
@@ -67,6 +67,9 @@ def get_llm(model_name: str = DEFAULT_BEDROCK_LLM_MODEL) -> LLM:
             messages_to_prompt=messages_to_prompt,
             completion_to_prompt=completion_to_prompt,
         )
+    if not model_name:
+        model_name = DEFAULT_BEDROCK_LLM_MODEL
+
     return BedrockConverse(
         model=model_name,
         # context_size=BEDROCK_MODELS.get(model_name, 8192),

--- a/llm-service/app/tests/conftest.py
+++ b/llm-service/app/tests/conftest.py
@@ -234,7 +234,7 @@ def llm(monkeypatch: pytest.MonkeyPatch) -> LLM:
     model = DummyLlm()
 
     # Requires that the app usages import the file and not the function directly as python creates a copy when importing the function
-    monkeypatch.setattr(models, "get_llm", lambda model_name: model)
+    monkeypatch.setattr(models, "get_llm", lambda : model)
     return model
 
 

--- a/local-dev.sh
+++ b/local-dev.sh
@@ -53,6 +53,8 @@ for sig in INT QUIT HUP TERM; do
 done
 trap cleanup EXIT
 
+docker stop qdrant_dev || true
+
 mkdir -p databases
 docker run --name qdrant_dev --rm -d -p 6333:6333 -p 6334:6334 -v $(pwd)/databases/qdrant_storage:/qdrant/storage:z qdrant/qdrant
 

--- a/ui/src/api/chatApi.ts
+++ b/ui/src/api/chatApi.ts
@@ -46,6 +46,7 @@ import {
 } from "src/api/utils.ts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { suggestedQuestionKey } from "src/api/ragQueryApi.ts";
+import { Session } from "src/api/sessionApi.ts";
 
 export interface SourceNode {
   node_id: string;
@@ -190,4 +191,18 @@ const chatMutation = async (
     `${llmServicePath}/sessions/${request.session_id}/chat`,
     request,
   );
+};
+
+export const createQueryConfiguration = (
+  queryConfiguration: QueryConfiguration,
+  activeSession?: Session,
+): QueryConfiguration => {
+  if (!activeSession) {
+    return queryConfiguration;
+  }
+  return {
+    ...queryConfiguration,
+    top_k: activeSession.responseChunks,
+    model_name: activeSession.inferenceModel ?? queryConfiguration.model_name,
+  };
 };

--- a/ui/src/api/chatApi.ts
+++ b/ui/src/api/chatApi.ts
@@ -194,15 +194,20 @@ const chatMutation = async (
 };
 
 export const createQueryConfiguration = (
-  queryConfiguration: QueryConfiguration,
+  excludeKnowledgeBase: boolean,
   activeSession?: Session,
 ): QueryConfiguration => {
+  // todo: maybe we should just throw an exception here?
   if (!activeSession) {
-    return queryConfiguration;
+    return {
+      top_k: 5,
+      model_name: "",
+      exclude_knowledge_base: false,
+    };
   }
   return {
-    ...queryConfiguration,
     top_k: activeSession.responseChunks,
-    model_name: activeSession.inferenceModel ?? queryConfiguration.model_name,
+    model_name: activeSession.inferenceModel ?? "",
+    exclude_knowledge_base: excludeKnowledgeBase,
   };
 };

--- a/ui/src/api/ragQueryApi.ts
+++ b/ui/src/api/ragQueryApi.ts
@@ -73,9 +73,7 @@ export const useSuggestQuestions = (request: SuggestQuestionsRequest) => {
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: suggestedQuestionKey(request.data_source_id),
     queryFn: () => suggestQuestionsQuery(request),
-    enabled:
-      Boolean(request.data_source_id) &&
-      Boolean(request.configuration.model_name),
+    enabled: Boolean(request.data_source_id),
     gcTime: 0,
   });
 };

--- a/ui/src/api/ragQueryApi.ts
+++ b/ui/src/api/ragQueryApi.ts
@@ -46,11 +46,6 @@ import {
   QueryKeys,
 } from "src/api/utils.ts";
 
-export interface RagMessage {
-  role: "user" | "assistant";
-  content: string;
-}
-
 export interface SuggestQuestionsRequest {
   data_source_id: string;
   configuration: QueryConfiguration;

--- a/ui/src/api/sessionApi.ts
+++ b/ui/src/api/sessionApi.ts
@@ -62,6 +62,16 @@ export interface Session {
   lastInteractionTime: number;
 }
 
+export type CreateSessionRequest = Pick<
+  Session,
+  "name" | "dataSourceIds" | "inferenceModel" | "responseChunks"
+>;
+
+export type UpdateSessionRequest = Pick<
+  Session,
+  "responseChunks" | "inferenceModel" | "name" | "id"
+>;
+
 export const getSessionsQueryOptions = queryOptions({
   queryKey: [QueryKeys.getSessions],
   queryFn: async () => await getSessionsQuery(),
@@ -70,13 +80,6 @@ export const getSessionsQueryOptions = queryOptions({
 export const getSessionsQuery = async (): Promise<Session[]> => {
   return await getRequest(`${ragPath}/${paths.sessions}`);
 };
-
-export interface CreateSessionRequest {
-  name: string;
-  dataSourceIds: number[];
-  inferenceModel: string;
-  responseChunks: number;
-}
 
 export const useCreateSessionMutation = ({
   onSuccess,
@@ -94,6 +97,27 @@ const createSessionMutation = async (
   request: CreateSessionRequest,
 ): Promise<Session> => {
   return await postRequest(`${ragPath}/${paths.sessions}`, request);
+};
+
+export const useUpdateSessionMutation = ({
+  onSuccess,
+  onError,
+}: UseMutationType<UpdateSessionRequest>) => {
+  return useMutation({
+    mutationKey: [MutationKeys.updateSession],
+    mutationFn: updateSessionMutation,
+    onSuccess,
+    onError,
+  });
+};
+
+const updateSessionMutation = async (
+  request: UpdateSessionRequest,
+): Promise<Session> => {
+  return await postRequest(
+    `${ragPath}/${paths.sessions}/${request.id.toString()}`,
+    request,
+  );
 };
 
 export const useDeleteSessionMutation = ({

--- a/ui/src/api/sessionApi.ts
+++ b/ui/src/api/sessionApi.ts
@@ -53,6 +53,8 @@ export interface Session {
   id: number;
   name: string;
   dataSourceIds: number[];
+  inferenceModel?: string;
+  responseChunks: number;
   timeCreated: number;
   timeUpdated: number;
   createdById: string;
@@ -72,6 +74,8 @@ export const getSessionsQuery = async (): Promise<Session[]> => {
 export interface CreateSessionRequest {
   name: string;
   dataSourceIds: number[];
+  inferenceModel: string;
+  responseChunks: number;
 }
 
 export const useCreateSessionMutation = ({

--- a/ui/src/api/utils.ts
+++ b/ui/src/api/utils.ts
@@ -68,6 +68,7 @@ export enum MutationKeys {
   "testLlmModel" = "testLlmModel",
   "testEmbeddingModel" = "testEmbeddingModel",
   "visualizeDataSourceWithUserQuery" = "visualizeDataSourceWithUserQuery",
+  "updateSession" = "updateSession",
 }
 
 export enum QueryKeys {

--- a/ui/src/pages/RagChatTab/ChatLayout.tsx
+++ b/ui/src/pages/RagChatTab/ChatLayout.tsx
@@ -64,10 +64,12 @@ const getDataSourceIdForSession = (session?: Session) => {
 function ChatLayout() {
   const { data: sessions } = useSuspenseQuery(getSessionsQueryOptions);
   const { data: llmModels } = useSuspenseQuery(getLlmModelsQueryOptions);
+
   const { sessionId } = useParams({ strict: false });
   const activeSession = getSessionForSessionId(sessionId, sessions);
   const dataSourceId = getDataSourceIdForSession(activeSession);
   const [currentQuestion, setCurrentQuestion] = useState("");
+
   const { data: dataSources, status: dataSourcesStatus } =
     useGetDataSourcesQuery();
   const [queryConfiguration, setQueryConfiguration] =
@@ -75,6 +77,7 @@ function ChatLayout() {
   const { status: chatHistoryStatus, data: chatHistory } = useChatHistoryQuery(
     sessionId?.toString() ?? "",
   );
+
   const dataSourceSize = useMemo(() => {
     return (
       dataSources?.find((ds) => ds.id === dataSourceId)?.totalDocSize ?? null

--- a/ui/src/pages/RagChatTab/ChatLayout.tsx
+++ b/ui/src/pages/RagChatTab/ChatLayout.tsx
@@ -91,16 +91,18 @@ function ChatLayout() {
     <RagChatContext.Provider
       value={{
         dataSourceId,
-        excludeKnowledgeBase,
-        setExcludeKnowledgeBase,
-        setCurrentQuestion,
-        currentQuestion,
-        chatHistory,
+        excludeKnowledgeBaseState: [
+          excludeKnowledgeBase,
+          setExcludeKnowledgeBase,
+        ],
+        currentQuestionState: [currentQuestion, setCurrentQuestion],
+        chatHistoryQuery: { chatHistory, chatHistoryStatus },
         dataSourceSize,
-        chatHistoryStatus,
-        dataSourcesStatus,
+        dataSourcesQuery: {
+          dataSources: dataSources ?? [],
+          dataSourcesStatus: dataSourcesStatus,
+        },
         activeSession,
-        dataSources: dataSources ?? [],
       }}
     >
       <Layout

--- a/ui/src/pages/RagChatTab/ChatLayout.tsx
+++ b/ui/src/pages/RagChatTab/ChatLayout.tsx
@@ -53,24 +53,20 @@ const getSessionForSessionId = (sessionId?: string, sessions?: Session[]) => {
   return sessions?.find((session) => session.id.toString() === sessionId);
 };
 
-const getDataSourceIdForSession = (session?: Session) => {
-  return session?.dataSourceIds[0];
-};
-
 function ChatLayout() {
   const { data: sessions } = useSuspenseQuery(getSessionsQueryOptions);
 
   const { sessionId } = useParams({ strict: false });
-  const activeSession = getSessionForSessionId(sessionId, sessions);
-  const dataSourceId = getDataSourceIdForSession(activeSession);
   const [currentQuestion, setCurrentQuestion] = useState("");
-
   const { data: dataSources, status: dataSourcesStatus } =
     useGetDataSourcesQuery();
   const [excludeKnowledgeBase, setExcludeKnowledgeBase] = useState(false);
   const { status: chatHistoryStatus, data: chatHistory } = useChatHistoryQuery(
     sessionId?.toString() ?? "",
   );
+
+  const activeSession = getSessionForSessionId(sessionId, sessions);
+  const dataSourceId = activeSession?.dataSourceIds[0];
 
   const dataSourceSize = useMemo(() => {
     return (
@@ -90,7 +86,6 @@ function ChatLayout() {
   return (
     <RagChatContext.Provider
       value={{
-        dataSourceId,
         excludeKnowledgeBaseState: [
           excludeKnowledgeBase,
           setExcludeKnowledgeBase,

--- a/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.test.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.test.tsx
@@ -37,7 +37,7 @@
  ******************************************************************************/
 
 import { cleanup, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   RagChatContext,
   RagChatContextType,
@@ -64,6 +64,8 @@ const testSession = {
   createdById: "1",
   updatedById: "1",
   lastInteractionTime: 123,
+  responseChunks: 5,
+  inferenceModel: "",
 };
 
 describe("ChatBodyController", () => {
@@ -96,16 +98,23 @@ describe("ChatBodyController", () => {
       chatHistory: [],
       dataSourceId: undefined,
       dataSourcesStatus: undefined,
-      queryConfiguration: {
-        top_k: 5,
-        model_name: "",
-        exclude_knowledge_base: false,
-      },
-      setQueryConfiguration: () => null,
       setCurrentQuestion: () => null,
+      excludeKnowledgeBase: false,
+      setExcludeKnowledgeBase: () => null,
       dataSourceSize: null,
       dataSources: [],
-      activeSession: undefined,
+      activeSession: {
+        dataSourceIds: [],
+        id: 0,
+        name: "",
+        timeCreated: 0,
+        timeUpdated: 0,
+        createdById: "",
+        updatedById: "",
+        lastInteractionTime: 0,
+        responseChunks: 5,
+        inferenceModel: "",
+      },
     };
 
     return render(

--- a/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.test.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.test.tsx
@@ -94,15 +94,12 @@ describe("ChatBodyController", () => {
 
   const renderWithContext = (contextValue: Partial<RagChatContextType>) => {
     const defaultContextValue: RagChatContextType = {
-      currentQuestion: "",
-      chatHistory: [],
+      chatHistoryQuery: { chatHistoryStatus: undefined, chatHistory: [] },
+      currentQuestionState: ["", () => null],
       dataSourceId: undefined,
-      dataSourcesStatus: undefined,
-      setCurrentQuestion: () => null,
-      excludeKnowledgeBase: false,
-      setExcludeKnowledgeBase: () => null,
+      dataSourcesQuery: { dataSourcesStatus: undefined, dataSources: [] },
+      excludeKnowledgeBaseState: [false, () => null],
       dataSourceSize: null,
-      dataSources: [],
       activeSession: {
         dataSourceIds: [],
         id: 0,
@@ -129,9 +126,8 @@ describe("ChatBodyController", () => {
   it("renders NoSessionState when no sessionId and dataSources are available", () => {
     renderWithContext({
       dataSourceId: undefined,
-      dataSourcesStatus: undefined,
+      dataSourcesQuery: { dataSourcesStatus: undefined, dataSources: [] },
       dataSourceSize: null,
-      dataSources: [],
       activeSession: undefined,
     });
 
@@ -140,7 +136,7 @@ describe("ChatBodyController", () => {
 
   it("renders ChatLoading when dataSourcesStatus or chatHistoryStatus is pending", () => {
     renderWithContext({
-      dataSourcesStatus: "pending",
+      dataSourcesQuery: { dataSourcesStatus: "pending", dataSources: [] },
     });
 
     expect(screen.getByTestId("chatLoadingSpinner")).toBeTruthy();
@@ -148,7 +144,7 @@ describe("ChatBodyController", () => {
 
   it("renders error message when dataSourcesStatus or chatHistoryStatus is error", () => {
     renderWithContext({
-      dataSourcesStatus: "error",
+      dataSourcesQuery: { dataSourcesStatus: "error", dataSources: [] },
     });
 
     expect(screen.getByText("We encountered an error")).toBeTruthy();
@@ -156,18 +152,21 @@ describe("ChatBodyController", () => {
 
   it("renders ChatMessageController when chatHistory exists", () => {
     renderWithContext({
-      chatHistory: [
-        {
-          id: "1",
-          rag_message: {
-            user: "a test question",
-            assistant: "a test response",
+      chatHistoryQuery: {
+        chatHistoryStatus: undefined,
+        chatHistory: [
+          {
+            id: "1",
+            rag_message: {
+              user: "a test question",
+              assistant: "a test response",
+            },
+            source_nodes: [],
+            evaluations: [],
+            timestamp: 123,
           },
-          source_nodes: [],
-          evaluations: [],
-          timestamp: 123,
-        },
-      ],
+        ],
+      },
     });
 
     expect(screen.getByTestId("chat-message")).toBeTruthy();
@@ -175,7 +174,7 @@ describe("ChatBodyController", () => {
 
   it("renders NoDataSourcesState when no dataSources are available", () => {
     renderWithContext({
-      dataSources: [],
+      dataSourcesQuery: { dataSources: [] },
       activeSession: testSession,
     });
 
@@ -188,7 +187,7 @@ describe("ChatBodyController", () => {
 
   it("renders NoDataSourceForSession when no currentDataSource is found", () => {
     renderWithContext({
-      dataSources: [testDataSource],
+      dataSourcesQuery: { dataSources: [testDataSource] },
       dataSourceId: undefined,
       activeSession: { ...testSession, dataSourceIds: [2] },
     });
@@ -200,9 +199,9 @@ describe("ChatBodyController", () => {
 
   it("renders ChatMessageController when currentQuestion and dataSourceSize are available", () => {
     renderWithContext({
-      currentQuestion: "What is AI?",
+      currentQuestionState: ["What is AI?", () => null],
       dataSourceSize: 1,
-      dataSources: [testDataSource],
+      dataSourcesQuery: { dataSources: [testDataSource] },
       activeSession: testSession,
     });
 
@@ -222,7 +221,7 @@ describe("ChatBodyController", () => {
 
     renderWithContext({
       dataSourceSize: 1,
-      dataSources: [testDataSource],
+      dataSourcesQuery: { dataSources: [testDataSource] },
       activeSession: testSession,
     });
 

--- a/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.test.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.test.tsx
@@ -96,7 +96,6 @@ describe("ChatBodyController", () => {
     const defaultContextValue: RagChatContextType = {
       chatHistoryQuery: { chatHistoryStatus: undefined, chatHistory: [] },
       currentQuestionState: ["", () => null],
-      dataSourceId: undefined,
       dataSourcesQuery: { dataSourcesStatus: undefined, dataSources: [] },
       excludeKnowledgeBaseState: [false, () => null],
       dataSourceSize: null,
@@ -125,7 +124,6 @@ describe("ChatBodyController", () => {
 
   it("renders NoSessionState when no sessionId and dataSources are available", () => {
     renderWithContext({
-      dataSourceId: undefined,
       dataSourcesQuery: { dataSourcesStatus: undefined, dataSources: [] },
       dataSourceSize: null,
       activeSession: undefined,
@@ -188,7 +186,6 @@ describe("ChatBodyController", () => {
   it("renders NoDataSourceForSession when no currentDataSource is found", () => {
     renderWithContext({
       dataSourcesQuery: { dataSources: [testDataSource] },
-      dataSourceId: undefined,
       activeSession: { ...testSession, dataSourceIds: [2] },
     });
 

--- a/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatBodyController.tsx
@@ -49,12 +49,10 @@ import NoDataSourceForSession from "pages/RagChatTab/ChatOutput/Placeholders/NoD
 
 const ChatBodyController = () => {
   const {
-    currentQuestion,
-    chatHistory,
-    dataSourcesStatus,
-    chatHistoryStatus,
+    currentQuestionState: [currentQuestion],
+    chatHistoryQuery: { chatHistory, chatHistoryStatus },
+    dataSourcesQuery: { dataSources, dataSourcesStatus },
     dataSourceSize,
-    dataSources,
     activeSession,
   } = useContext(RagChatContext);
   const { sessionId } = useParams({ strict: false });

--- a/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatMessageController.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatMessageController.tsx
@@ -41,7 +41,10 @@ import ChatMessage from "pages/RagChatTab/ChatOutput/ChatMessages/ChatMessage.ts
 import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
 
 const ChatMessageController = () => {
-  const { chatHistory, dataSourceId } = useContext(RagChatContext);
+  const {
+    chatHistoryQuery: { chatHistory },
+    dataSourceId,
+  } = useContext(RagChatContext);
   const scrollEl = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatMessageController.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/ChatMessages/ChatMessageController.tsx
@@ -43,9 +43,10 @@ import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
 const ChatMessageController = () => {
   const {
     chatHistoryQuery: { chatHistory },
-    dataSourceId,
+    activeSession,
   } = useContext(RagChatContext);
   const scrollEl = useRef<HTMLDivElement>(null);
+  const dataSourceId = activeSession?.dataSourceIds[0];
 
   useEffect(() => {
     setTimeout(() => {

--- a/ui/src/pages/RagChatTab/ChatOutput/Placeholders/EmptyChatState.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/Placeholders/EmptyChatState.tsx
@@ -46,8 +46,8 @@ import { cdlGray700 } from "src/cuix/variables.ts";
 import Images from "src/components/images/Images.ts";
 
 const DataSourceSummaryCard = () => {
-  const { dataSourceId } = useContext(RagChatContext);
-
+  const { activeSession } = useContext(RagChatContext);
+  const dataSourceId = activeSession?.dataSourceIds[0];
   const dataSourceSummary = useGetDataSourceSummary({
     data_source_id: dataSourceId?.toString() ?? "",
     queryEnabled: true,
@@ -81,7 +81,9 @@ const DataSourceSummaryCard = () => {
 };
 
 const EmptyChatState = ({ dataSourceSize }: { dataSourceSize: number }) => {
-  const { dataSourceId } = useContext(RagChatContext);
+  const { activeSession } = useContext(RagChatContext);
+  const dataSourceId = activeSession?.dataSourceIds[0];
+
   return (
     <Flex vertical align="center" style={{ height: "100%" }}>
       <Image

--- a/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
@@ -46,9 +46,9 @@ import { createQueryConfiguration, useChatMutation } from "src/api/chatApi.ts";
 const SuggestedQuestionsCards = () => {
   const {
     dataSourceId,
-    setCurrentQuestion,
+    currentQuestionState: [, setCurrentQuestion],
     activeSession,
-    excludeKnowledgeBase,
+    excludeKnowledgeBaseState: [excludeKnowledgeBase],
   } = useContext(RagChatContext);
 
   const sessionId = activeSession?.id.toString();

--- a/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
@@ -41,21 +41,24 @@ import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
 import { useContext } from "react";
 import { useSuggestQuestions } from "src/api/ragQueryApi.ts";
 import messageQueue from "src/utils/messageQueue.ts";
-import { useChatMutation } from "src/api/chatApi.ts";
-import { useParams } from "@tanstack/react-router";
+import { createQueryConfiguration, useChatMutation } from "src/api/chatApi.ts";
 
 const SuggestedQuestionsCards = () => {
-  const { dataSourceId, setCurrentQuestion, queryConfiguration } =
-    useContext(RagChatContext);
-  const { sessionId } = useParams({ strict: false });
+  const {
+    dataSourceId,
+    setCurrentQuestion,
+    queryConfiguration,
+    activeSession,
+  } = useContext(RagChatContext);
 
+  const sessionId = activeSession?.id.toString();
   const {
     data,
     isPending: suggestedQuestionsIsPending,
     isFetching: suggestedQuestionsIsFetching,
   } = useSuggestQuestions({
     data_source_id: dataSourceId?.toString() ?? "",
-    configuration: queryConfiguration,
+    configuration: createQueryConfiguration(queryConfiguration, activeSession),
     session_id: sessionId ?? "",
   });
 
@@ -80,7 +83,10 @@ const SuggestedQuestionsCards = () => {
         query: suggestedQuestion,
         data_source_id: dataSourceId.toString(),
         session_id: sessionId,
-        configuration: queryConfiguration,
+        configuration: createQueryConfiguration(
+          queryConfiguration,
+          activeSession,
+        ),
       });
     }
   };

--- a/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
@@ -47,8 +47,8 @@ const SuggestedQuestionsCards = () => {
   const {
     dataSourceId,
     setCurrentQuestion,
-    queryConfiguration,
     activeSession,
+    excludeKnowledgeBase,
   } = useContext(RagChatContext);
 
   const sessionId = activeSession?.id.toString();
@@ -58,7 +58,10 @@ const SuggestedQuestionsCards = () => {
     isFetching: suggestedQuestionsIsFetching,
   } = useSuggestQuestions({
     data_source_id: dataSourceId?.toString() ?? "",
-    configuration: createQueryConfiguration(queryConfiguration, activeSession),
+    configuration: createQueryConfiguration(
+      excludeKnowledgeBase,
+      activeSession,
+    ),
     session_id: sessionId ?? "",
   });
 
@@ -84,7 +87,7 @@ const SuggestedQuestionsCards = () => {
         data_source_id: dataSourceId.toString(),
         session_id: sessionId,
         configuration: createQueryConfiguration(
-          queryConfiguration,
+          excludeKnowledgeBase,
           activeSession,
         ),
       });

--- a/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/Placeholders/SuggestedQuestionsCards.tsx
@@ -45,12 +45,11 @@ import { createQueryConfiguration, useChatMutation } from "src/api/chatApi.ts";
 
 const SuggestedQuestionsCards = () => {
   const {
-    dataSourceId,
     currentQuestionState: [, setCurrentQuestion],
     activeSession,
     excludeKnowledgeBaseState: [excludeKnowledgeBase],
   } = useContext(RagChatContext);
-
+  const dataSourceId = activeSession?.dataSourceIds[0];
   const sessionId = activeSession?.id.toString();
   const {
     data,

--- a/ui/src/pages/RagChatTab/ChatOutput/Sources/SourceCard.tsx
+++ b/ui/src/pages/RagChatTab/ChatOutput/Sources/SourceCard.tsx
@@ -57,9 +57,10 @@ import { cdlGray600 } from "src/cuix/variables.ts";
 import MetaData from "pages/RagChatTab/ChatOutput/Sources/MetaData.tsx";
 
 export const SourceCard = ({ source }: { source: SourceNode }) => {
-  const { dataSourceId } = useContext(RagChatContext);
+  const { activeSession } = useContext(RagChatContext);
   const [showContent, setShowContent] = useState(false);
   const chunkContents = useGetChunkContents();
+  const dataSourceId = activeSession?.dataSourceIds[0];
   const documentSummary = useGetDocumentSummary({
     data_source_id: dataSourceId?.toString() ?? "",
     doc_id: source.doc_id,

--- a/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
+++ b/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
@@ -51,7 +51,6 @@ import type { SwitchChangeEventHandler } from "antd/lib/switch";
 
 const RagChatQueryInput = () => {
   const {
-    dataSourceId,
     excludeKnowledgeBaseState: [excludeKnowledgeBase, setExcludeKnowledgeBase],
     currentQuestionState: [, setCurrentQuestion],
     chatHistoryQuery: { chatHistory },
@@ -59,7 +58,7 @@ const RagChatQueryInput = () => {
     dataSourcesQuery: { dataSourcesStatus },
     activeSession,
   } = useContext(RagChatContext);
-
+  const dataSourceId = activeSession?.dataSourceIds[0];
   const [userInput, setUserInput] = useState("");
   const { sessionId } = useParams({ strict: false });
 

--- a/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
+++ b/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
@@ -52,27 +52,28 @@ import type { SwitchChangeEventHandler } from "antd/lib/switch";
 const RagChatQueryInput = () => {
   const {
     dataSourceId,
-    excludeKnowledgeBase,
-    setExcludeKnowledgeBase,
-    setCurrentQuestion,
-    chatHistory,
+    excludeKnowledgeBaseState: [excludeKnowledgeBase, setExcludeKnowledgeBase],
+    currentQuestionState: [, setCurrentQuestion],
+    chatHistoryQuery: { chatHistory },
     dataSourceSize,
-    dataSourcesStatus,
+    dataSourcesQuery: { dataSourcesStatus },
     activeSession,
   } = useContext(RagChatContext);
 
   const [userInput, setUserInput] = useState("");
   const { sessionId } = useParams({ strict: false });
+
+  const configuration = createQueryConfiguration(
+    excludeKnowledgeBase,
+    activeSession,
+  );
   const {
     data: sampleQuestions,
     isPending: sampleQuestionsIsPending,
     isFetching: sampleQuestionsIsFetching,
   } = useSuggestQuestions({
     data_source_id: dataSourceId?.toString() ?? "",
-    configuration: createQueryConfiguration(
-      excludeKnowledgeBase,
-      activeSession,
-    ),
+    configuration,
     session_id: sessionId ?? "",
   });
 

--- a/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
+++ b/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
@@ -42,7 +42,7 @@ import { DatabaseFilled, SendOutlined } from "@ant-design/icons";
 import { useContext, useState } from "react";
 import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
 import messageQueue from "src/utils/messageQueue.ts";
-import { useChatMutation } from "src/api/chatApi.ts";
+import { createQueryConfiguration, useChatMutation } from "src/api/chatApi.ts";
 import { useSuggestQuestions } from "src/api/ragQueryApi.ts";
 import { useParams } from "@tanstack/react-router";
 import { cdlBlue600 } from "src/cuix/variables.ts";
@@ -58,18 +58,18 @@ const RagChatQueryInput = () => {
     dataSourceSize,
     dataSourcesStatus,
     setQueryConfiguration,
+    activeSession,
   } = useContext(RagChatContext);
 
   const [userInput, setUserInput] = useState("");
   const { sessionId } = useParams({ strict: false });
-
   const {
     data: sampleQuestions,
     isPending: sampleQuestionsIsPending,
     isFetching: sampleQuestionsIsFetching,
   } = useSuggestQuestions({
     data_source_id: dataSourceId?.toString() ?? "",
-    configuration: queryConfiguration,
+    configuration: createQueryConfiguration(queryConfiguration, activeSession),
     session_id: sessionId ?? "",
   });
 
@@ -90,7 +90,10 @@ const RagChatQueryInput = () => {
         query: userInput,
         data_source_id: dataSourceId.toString(),
         session_id: sessionId,
-        configuration: queryConfiguration,
+        configuration: createQueryConfiguration(
+          queryConfiguration,
+          activeSession,
+        ),
       });
     }
   };

--- a/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
+++ b/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
@@ -52,12 +52,12 @@ import type { SwitchChangeEventHandler } from "antd/lib/switch";
 const RagChatQueryInput = () => {
   const {
     dataSourceId,
-    queryConfiguration,
+    excludeKnowledgeBase,
+    setExcludeKnowledgeBase,
     setCurrentQuestion,
     chatHistory,
     dataSourceSize,
     dataSourcesStatus,
-    setQueryConfiguration,
     activeSession,
   } = useContext(RagChatContext);
 
@@ -69,7 +69,10 @@ const RagChatQueryInput = () => {
     isFetching: sampleQuestionsIsFetching,
   } = useSuggestQuestions({
     data_source_id: dataSourceId?.toString() ?? "",
-    configuration: createQueryConfiguration(queryConfiguration, activeSession),
+    configuration: createQueryConfiguration(
+      excludeKnowledgeBase,
+      activeSession,
+    ),
     session_id: sessionId ?? "",
   });
 
@@ -91,7 +94,7 @@ const RagChatQueryInput = () => {
         data_source_id: dataSourceId.toString(),
         session_id: sessionId,
         configuration: createQueryConfiguration(
-          queryConfiguration,
+          excludeKnowledgeBase,
           activeSession,
         ),
       });
@@ -99,10 +102,7 @@ const RagChatQueryInput = () => {
   };
 
   const handleExcludeKnowledgeBase: SwitchChangeEventHandler = (checked) => {
-    setQueryConfiguration((prev) => ({
-      ...prev,
-      exclude_knowledge_base: !checked,
-    }));
+    setExcludeKnowledgeBase(() => !checked);
   };
 
   return (
@@ -136,7 +136,7 @@ const RagChatQueryInput = () => {
               <Tooltip title="Whether to query against the knowledge base.  Disabling will query only against the model's training data.">
                 <Switch
                   checkedChildren={<DatabaseFilled />}
-                  value={!queryConfiguration.exclude_knowledge_base}
+                  value={!excludeKnowledgeBase}
                   onChange={handleExcludeKnowledgeBase}
                 />
               </Tooltip>

--- a/ui/src/pages/RagChatTab/Header/RagChatHeader.tsx
+++ b/ui/src/pages/RagChatTab/Header/RagChatHeader.tsx
@@ -38,14 +38,14 @@
 
 import { Session } from "src/api/sessionApi.ts";
 import { DataSourceType } from "src/api/dataSourceApi.ts";
-import { Button, Flex, Layout, Tooltip, Typography } from "antd";
+import { Button, Flex, Layout, Typography } from "antd";
 import QueryTimeSettingsModal from "pages/RagChatTab/Settings/QueryTimeSettingsModal.tsx";
 import { useContext } from "react";
 import { QueryConfiguration } from "src/api/chatApi.ts";
 import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
 import useModal from "src/utils/useModal.ts";
 import SettingsIcon from "src/cuix/icons/SettingsIcon";
-import { cdlBlue600 } from "src/cuix/variables.ts";
+import { cdlBlue600, cdlGray600 } from "src/cuix/variables.ts";
 
 const { Header } = Layout;
 
@@ -62,7 +62,10 @@ function getHeaderTitle(
   return `${activeSession.name} / ${currentDataSource.name}`;
 }
 
-export const RagChatHeader = (props: {
+export const RagChatHeader = ({
+  activeSession,
+  currentDataSource,
+}: {
   activeSession?: Session;
   currentDataSource?: DataSourceType;
 }) => {
@@ -91,25 +94,29 @@ export const RagChatHeader = (props: {
             marginBottom: 0,
           }}
         >
-          {getHeaderTitle(props.activeSession, props.currentDataSource)}
+          {getHeaderTitle(activeSession, currentDataSource)}
         </Typography.Title>
-        <Tooltip title={"Query-Time Settings"}>
-          <Button
-            style={{ width: 116, alignItems: "center" }}
-            onClick={handleOpenModal}
+        <Button
+          style={{ width: 140, alignItems: "center" }}
+          onClick={handleOpenModal}
+          disabled={!activeSession}
+        >
+          <Flex
+            align="center"
+            gap={5}
+            style={{ margin: 0, padding: 0, height: "100%" }}
           >
-            <Flex
-              align="center"
-              gap={5}
-              style={{ margin: 0, padding: 0, height: "100%" }}
+            <SettingsIcon
+              color={activeSession ? cdlBlue600 : cdlGray600}
+              fontSize={18}
+            />
+            <Typography.Text
+              style={{ color: activeSession ? cdlBlue600 : cdlGray600 }}
             >
-              <SettingsIcon color={cdlBlue600} fontSize={18} />
-              <Typography.Text style={{ color: cdlBlue600 }}>
-                Settings
-              </Typography.Text>
-            </Flex>
-          </Button>
-        </Tooltip>
+              Chat Settings
+            </Typography.Text>
+          </Flex>
+        </Button>
       </Flex>{" "}
       <QueryTimeSettingsModal
         open={settingsModal.isModalOpen}

--- a/ui/src/pages/RagChatTab/Header/RagChatHeader.tsx
+++ b/ui/src/pages/RagChatTab/Header/RagChatHeader.tsx
@@ -39,10 +39,7 @@
 import { Session } from "src/api/sessionApi.ts";
 import { DataSourceType } from "src/api/dataSourceApi.ts";
 import { Button, Flex, Layout, Typography } from "antd";
-import QueryTimeSettingsModal from "pages/RagChatTab/Settings/QueryTimeSettingsModal.tsx";
-import { useContext } from "react";
-import { QueryConfiguration } from "src/api/chatApi.ts";
-import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
+import ChatSettingsModal from "pages/RagChatTab/Settings/ChatSettingsModal.tsx";
 import useModal from "src/utils/useModal.ts";
 import SettingsIcon from "src/cuix/icons/SettingsIcon";
 import { cdlBlue600, cdlGray600 } from "src/cuix/variables.ts";
@@ -69,18 +66,12 @@ export const RagChatHeader = ({
   activeSession?: Session;
   currentDataSource?: DataSourceType;
 }) => {
-  const { queryConfiguration, setQueryConfiguration } =
-    useContext(RagChatContext);
   const settingsModal = useModal();
 
   const handleOpenModal = () => {
     settingsModal.setIsModalOpen(!settingsModal.isModalOpen);
   };
 
-  const handleUpdateConfiguration = (formValues: QueryConfiguration) => {
-    setQueryConfiguration(formValues);
-    settingsModal.setIsModalOpen(false);
-  };
   return (
     <Header style={{ padding: 0, margin: 0, width: "100%" }}>
       <Flex justify="space-between">
@@ -118,13 +109,11 @@ export const RagChatHeader = ({
           </Flex>
         </Button>
       </Flex>{" "}
-      <QueryTimeSettingsModal
+      <ChatSettingsModal
         open={settingsModal.isModalOpen}
         closeModal={() => {
           settingsModal.setIsModalOpen(false);
         }}
-        queryConfiguration={queryConfiguration}
-        handleUpdateConfiguration={handleUpdateConfiguration}
       />
     </Header>
   );

--- a/ui/src/pages/RagChatTab/RagChat.tsx
+++ b/ui/src/pages/RagChatTab/RagChat.tsx
@@ -46,8 +46,11 @@ import { RagChatHeader } from "pages/RagChatTab/Header/RagChatHeader.tsx";
 const { Footer, Content } = Layout;
 
 const RagChat = () => {
-  const { dataSourceId, dataSources, activeSession } =
-    useContext(RagChatContext);
+  const {
+    dataSourceId,
+    dataSourcesQuery: { dataSources },
+    activeSession,
+  } = useContext(RagChatContext);
 
   const currentDataSource = dataSources.find((dataSource) => {
     return dataSource.id === dataSourceId;

--- a/ui/src/pages/RagChatTab/RagChat.tsx
+++ b/ui/src/pages/RagChatTab/RagChat.tsx
@@ -47,13 +47,12 @@ const { Footer, Content } = Layout;
 
 const RagChat = () => {
   const {
-    dataSourceId,
     dataSourcesQuery: { dataSources },
     activeSession,
   } = useContext(RagChatContext);
 
   const currentDataSource = dataSources.find((dataSource) => {
-    return dataSource.id === dataSourceId;
+    return dataSource.id === activeSession?.dataSourceIds[0];
   });
 
   return (

--- a/ui/src/pages/RagChatTab/Sessions/CreateSessionForm.tsx
+++ b/ui/src/pages/RagChatTab/Sessions/CreateSessionForm.tsx
@@ -39,6 +39,9 @@
 import { Form, FormInstance, Input, Select } from "antd";
 import { DataSourceType } from "src/api/dataSourceApi.ts";
 import { CreateSessionType } from "pages/RagChatTab/Sessions/CreateSessionModal.tsx";
+import { transformModelOptions } from "src/utils/modelUtils.ts";
+import ResponseChunksSlider from "pages/RagChatTab/Settings/ResponseChunksSlider.tsx";
+import { useGetLlmModels } from "src/api/modelsApi.ts";
 
 export interface CreateSessionFormProps {
   form: FormInstance<CreateSessionType>;
@@ -51,6 +54,8 @@ const layout = {
 };
 
 const CreateSessionForm = ({ form, dataSources }: CreateSessionFormProps) => {
+  const { data } = useGetLlmModels();
+
   const formatDataSource = (value: DataSourceType) => {
     return {
       ...value,
@@ -88,6 +93,23 @@ const CreateSessionForm = ({ form, dataSources }: CreateSessionFormProps) => {
       </Form.Item>
       <Form.Item name="name" label="Name" rules={[{ required: true }]}>
         <Input />
+      </Form.Item>
+      <Form.Item<CreateSessionType>
+        initialValue={
+          data === undefined || data.length === 0 ? "" : data[0].model_id
+        }
+        name="inferenceModel"
+        label="Response synthesizer model"
+        rules={[{ required: true }]}
+      >
+        <Select options={transformModelOptions(data)} />
+      </Form.Item>
+      <Form.Item<CreateSessionType>
+        name="responseChunks"
+        initialValue={5}
+        label="Maximum number of documents"
+      >
+        <ResponseChunksSlider />
       </Form.Item>
     </Form>
   );

--- a/ui/src/pages/RagChatTab/Sessions/CreateSessionForm.tsx
+++ b/ui/src/pages/RagChatTab/Sessions/CreateSessionForm.tsx
@@ -36,11 +36,11 @@
  * DATA.
  ******************************************************************************/
 
-import { Form, FormInstance, Input, Select } from "antd";
+import { Form, FormInstance, Input, Select, Slider } from "antd";
 import { DataSourceType } from "src/api/dataSourceApi.ts";
 import { CreateSessionType } from "pages/RagChatTab/Sessions/CreateSessionModal.tsx";
 import { transformModelOptions } from "src/utils/modelUtils.ts";
-import ResponseChunksSlider from "pages/RagChatTab/Settings/ResponseChunksSlider.tsx";
+import { ResponseChunksRange } from "pages/RagChatTab/Settings/ResponseChunksSlider.tsx";
 import { useGetLlmModels } from "src/api/modelsApi.ts";
 
 export interface CreateSessionFormProps {
@@ -49,8 +49,8 @@ export interface CreateSessionFormProps {
 }
 
 const layout = {
-  labelCol: { span: 8 },
-  wrapperCol: { span: 16 },
+  labelCol: { span: 12 },
+  wrapperCol: { span: 12 },
 };
 
 const CreateSessionForm = ({ form, dataSources }: CreateSessionFormProps) => {
@@ -109,7 +109,7 @@ const CreateSessionForm = ({ form, dataSources }: CreateSessionFormProps) => {
         initialValue={5}
         label="Maximum number of documents"
       >
-        <ResponseChunksSlider />
+        <Slider marks={ResponseChunksRange} min={1} max={10} />
       </Form.Item>
     </Form>
   );

--- a/ui/src/pages/RagChatTab/Sessions/CreateSessionModal.tsx
+++ b/ui/src/pages/RagChatTab/Sessions/CreateSessionModal.tsx
@@ -52,6 +52,8 @@ import { useNavigate } from "@tanstack/react-router";
 export interface CreateSessionType {
   name: string;
   dataSourceId: number;
+  inferenceModel: string;
+  responseChunks: number;
 }
 
 const CreateSessionModal = ({
@@ -95,6 +97,8 @@ const CreateSessionModal = ({
         const responseBody: CreateSessionRequest = {
           name: values.name,
           dataSourceIds: [values.dataSourceId],
+          inferenceModel: values.inferenceModel,
+          responseChunks: values.responseChunks,
         };
         createSessionMutation(responseBody);
       })

--- a/ui/src/pages/RagChatTab/Sessions/CreateSessionModal.tsx
+++ b/ui/src/pages/RagChatTab/Sessions/CreateSessionModal.tsx
@@ -111,6 +111,7 @@ const CreateSessionModal = ({
     <Modal
       title="Create New Chat"
       open={isModalOpen}
+      width={600}
       onOk={() => {
         setIsModalOpen(false);
       }}

--- a/ui/src/pages/RagChatTab/Sessions/CreateSessionModal.tsx
+++ b/ui/src/pages/RagChatTab/Sessions/CreateSessionModal.tsx
@@ -67,7 +67,9 @@ const CreateSessionModal = ({
 }) => {
   const [form] = Form.useForm<CreateSessionType>();
   const queryClient = useQueryClient();
-  const { dataSources } = useContext(RagChatContext);
+  const {
+    dataSourcesQuery: { dataSources },
+  } = useContext(RagChatContext);
   const navigate = useNavigate();
   const { mutate: createSessionMutation } = useCreateSessionMutation({
     onSuccess: async (data) => {

--- a/ui/src/pages/RagChatTab/Sessions/SessionSidebar.tsx
+++ b/ui/src/pages/RagChatTab/Sessions/SessionSidebar.tsx
@@ -95,7 +95,9 @@ export function SessionSidebar({
 }: {
   sessionsByDate: Dictionary<Session[]>;
 }) {
-  const { dataSources } = useContext(RagChatContext);
+  const {
+    dataSourcesQuery: { dataSources },
+  } = useContext(RagChatContext);
   const { isModalOpen, setIsModalOpen, showModal, handleCancel } = useModal();
   const { activeSession } = useContext(RagChatContext);
   const [collapsed, setCollapsed] = useState(false);

--- a/ui/src/pages/RagChatTab/Settings/ChatSettingsModal.tsx
+++ b/ui/src/pages/RagChatTab/Settings/ChatSettingsModal.tsx
@@ -37,7 +37,6 @@
  ******************************************************************************/
 
 import { Flex, Form, Input, Modal, Select, Slider } from "antd";
-import { QueryConfiguration } from "src/api/chatApi.ts";
 import RequestModels from "pages/RagChatTab/Settings/RequestModels.tsx";
 import { useGetLlmModels } from "src/api/modelsApi.ts";
 import { transformModelOptions } from "src/utils/modelUtils.ts";
@@ -46,23 +45,25 @@ import { useContext } from "react";
 import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
 import { Session } from "src/api/sessionApi.ts";
 
-const QueryTimeSettingsModal = ({
+const ChatSettingsModal = ({
   open,
   closeModal,
-  handleUpdateConfiguration,
 }: {
   open: boolean;
   closeModal: () => void;
-  queryConfiguration: QueryConfiguration;
-  handleUpdateConfiguration: (queryConfiguration: QueryConfiguration) => void;
 }) => {
-  const [form] = Form.useForm<Session>();
   const { data } = useGetLlmModels();
   const { activeSession } = useContext(RagChatContext);
+  const [form] = Form.useForm<Session>();
 
   if (!activeSession) {
     return null;
   }
+
+  const handleUpdateSession = (session: Session) => {
+    console.log("TODO Updating session", session);
+    closeModal();
+  };
 
   return (
     <Modal
@@ -70,23 +71,21 @@ const QueryTimeSettingsModal = ({
       open={open}
       onCancel={closeModal}
       onOk={() => {
-        handleUpdateConfiguration(form.getFieldsValue());
+        handleUpdateSession(form.getFieldsValue());
       }}
       maskClosable={false}
       width={600}
     >
       <Flex vertical gap={10}>
-        <Form autoCorrect="off" form={form}>
+        <Form autoCorrect="off" form={form} initialValues={activeSession}>
           <Form.Item<Session>
             name="name"
             label="Name"
             rules={[{ required: true }]}
-            initialValue={activeSession.name}
           >
             <Input />
           </Form.Item>
           <Form.Item<Session>
-            initialValue={activeSession.inferenceModel}
             name="inferenceModel"
             label="Response synthesizer model"
           >
@@ -106,4 +105,4 @@ const QueryTimeSettingsModal = ({
   );
 };
 
-export default QueryTimeSettingsModal;
+export default ChatSettingsModal;

--- a/ui/src/pages/RagChatTab/Settings/ChatSettingsModal.tsx
+++ b/ui/src/pages/RagChatTab/Settings/ChatSettingsModal.tsx
@@ -56,7 +56,7 @@ const ChatSettingsModal = ({
   open: boolean;
   closeModal: () => void;
 }) => {
-  const { data } = useGetLlmModels();
+  const { data: llmModels } = useGetLlmModels();
   const { activeSession } = useContext(RagChatContext);
   const [form] = Form.useForm<Omit<UpdateSessionRequest, "id">>();
   const updateSession = useUpdateSessionMutation({
@@ -112,10 +112,13 @@ const ChatSettingsModal = ({
           <Form.Item
             name="inferenceModel"
             label="Response synthesizer model"
-            initialValue={activeSession.inferenceModel}
+            initialValue={
+              activeSession.inferenceModel ??
+              (llmModels ? llmModels[0].model_id : "")
+            }
             rules={[{ required: true, message: "Please select a model" }]}
           >
-            <Select options={transformModelOptions(data)} />
+            <Select options={transformModelOptions(llmModels)} />
           </Form.Item>
           <RequestModels />
           <Form.Item

--- a/ui/src/pages/RagChatTab/Settings/ChatSettingsModal.tsx
+++ b/ui/src/pages/RagChatTab/Settings/ChatSettingsModal.tsx
@@ -48,6 +48,8 @@ import {
   useUpdateSessionMutation,
 } from "src/api/sessionApi.ts";
 import messageQueue from "src/utils/messageQueue.ts";
+import { QueryKeys } from "src/api/utils.ts";
+import { useQueryClient } from "@tanstack/react-query";
 
 const ChatSettingsModal = ({
   open,
@@ -59,13 +61,17 @@ const ChatSettingsModal = ({
   const { data: llmModels } = useGetLlmModels();
   const { activeSession } = useContext(RagChatContext);
   const [form] = Form.useForm<Omit<UpdateSessionRequest, "id">>();
+  const queryClient = useQueryClient();
   const updateSession = useUpdateSessionMutation({
     onError: (error) => {
       console.error(error);
       messageQueue.error("Failed to update session");
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       messageQueue.success("Session updated successfully");
+      await queryClient.invalidateQueries({
+        queryKey: [QueryKeys.getSessions],
+      });
       closeModal();
     },
   });

--- a/ui/src/pages/RagChatTab/Settings/QueryTimeSettingsModal.tsx
+++ b/ui/src/pages/RagChatTab/Settings/QueryTimeSettingsModal.tsx
@@ -36,17 +36,19 @@
  * DATA.
  ******************************************************************************/
 
-import { Flex, Form, Modal, Select } from "antd";
+import { Flex, Form, Input, Modal, Select, Slider } from "antd";
 import { QueryConfiguration } from "src/api/chatApi.ts";
 import RequestModels from "pages/RagChatTab/Settings/RequestModels.tsx";
 import { useGetLlmModels } from "src/api/modelsApi.ts";
 import { transformModelOptions } from "src/utils/modelUtils.ts";
-import ResponseChunksSlider from "pages/RagChatTab/Settings/ResponseChunksSlider.tsx";
+import { ResponseChunksRange } from "pages/RagChatTab/Settings/ResponseChunksSlider.tsx";
+import { useContext } from "react";
+import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
+import { Session } from "src/api/sessionApi.ts";
 
 const QueryTimeSettingsModal = ({
   open,
   closeModal,
-  queryConfiguration,
   handleUpdateConfiguration,
 }: {
   open: boolean;
@@ -54,12 +56,17 @@ const QueryTimeSettingsModal = ({
   queryConfiguration: QueryConfiguration;
   handleUpdateConfiguration: (queryConfiguration: QueryConfiguration) => void;
 }) => {
-  const [form] = Form.useForm<QueryConfiguration>();
+  const [form] = Form.useForm<Session>();
   const { data } = useGetLlmModels();
+  const { activeSession } = useContext(RagChatContext);
+
+  if (!activeSession) {
+    return null;
+  }
 
   return (
     <Modal
-      title="Query-Time Settings"
+      title={`Chat Settings: ${activeSession.name}`}
       open={open}
       onCancel={closeModal}
       onOk={() => {
@@ -70,20 +77,28 @@ const QueryTimeSettingsModal = ({
     >
       <Flex vertical gap={10}>
         <Form autoCorrect="off" form={form}>
-          <Form.Item<QueryConfiguration>
-            initialValue={queryConfiguration.model_name}
-            name="model_name"
+          <Form.Item<Session>
+            name="name"
+            label="Name"
+            rules={[{ required: true }]}
+            initialValue={activeSession.name}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item<Session>
+            initialValue={activeSession.inferenceModel}
+            name="inferenceModel"
             label="Response synthesizer model"
           >
             <Select options={transformModelOptions(data)} />
           </Form.Item>
           <RequestModels />
-          <Form.Item<QueryConfiguration>
-            name="top_k"
-            initialValue={queryConfiguration.top_k}
+          <Form.Item<Session>
+            name="responseChunks"
+            initialValue={activeSession.responseChunks}
             label="Maximum number of documents"
           >
-            <ResponseChunksSlider />
+            <Slider marks={ResponseChunksRange} min={1} max={10} />
           </Form.Item>
         </Form>
       </Flex>

--- a/ui/src/pages/RagChatTab/Settings/ResponseChunksSlider.tsx
+++ b/ui/src/pages/RagChatTab/Settings/ResponseChunksSlider.tsx
@@ -35,15 +35,9 @@
  * BUSINESS ADVANTAGE OR UNAVAILABILITY, OR LOSS OR CORRUPTION OF
  * DATA.
  ******************************************************************************/
-import { Slider, SliderSingleProps } from "antd";
+import { SliderSingleProps } from "antd";
 
-const marks: SliderSingleProps["marks"] = {
+export const ResponseChunksRange: SliderSingleProps["marks"] = {
   1: "1",
   10: "10",
 };
-
-const ResponseChunksSlider = () => {
-  return <Slider marks={marks} min={1} max={10} />;
-};
-
-export default ResponseChunksSlider;

--- a/ui/src/pages/RagChatTab/Settings/ResponseChunksSlider.tsx
+++ b/ui/src/pages/RagChatTab/Settings/ResponseChunksSlider.tsx
@@ -20,7 +20,7 @@
  * with an authorized and properly licensed third party, you do not
  * have any rights to access nor to use this code.
  *
- * Absent a written agreement with Cloudera, Inc. (“Cloudera”) to the
+ * Absent a written agreement with Cloudera, Inc. ("Cloudera") to the
  * contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
  * KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
  * WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
@@ -35,60 +35,15 @@
  * BUSINESS ADVANTAGE OR UNAVAILABILITY, OR LOSS OR CORRUPTION OF
  * DATA.
  ******************************************************************************/
+import { Slider, SliderSingleProps } from "antd";
 
-import { Flex, Form, Modal, Select } from "antd";
-import { QueryConfiguration } from "src/api/chatApi.ts";
-import RequestModels from "pages/RagChatTab/Settings/RequestModels.tsx";
-import { useGetLlmModels } from "src/api/modelsApi.ts";
-import { transformModelOptions } from "src/utils/modelUtils.ts";
-import ResponseChunksSlider from "pages/RagChatTab/Settings/ResponseChunksSlider.tsx";
-
-const QueryTimeSettingsModal = ({
-  open,
-  closeModal,
-  queryConfiguration,
-  handleUpdateConfiguration,
-}: {
-  open: boolean;
-  closeModal: () => void;
-  queryConfiguration: QueryConfiguration;
-  handleUpdateConfiguration: (queryConfiguration: QueryConfiguration) => void;
-}) => {
-  const [form] = Form.useForm<QueryConfiguration>();
-  const { data } = useGetLlmModels();
-
-  return (
-    <Modal
-      title="Query-Time Settings"
-      open={open}
-      onCancel={closeModal}
-      onOk={() => {
-        handleUpdateConfiguration(form.getFieldsValue());
-      }}
-      maskClosable={false}
-      width={600}
-    >
-      <Flex vertical gap={10}>
-        <Form autoCorrect="off" form={form}>
-          <Form.Item<QueryConfiguration>
-            initialValue={queryConfiguration.model_name}
-            name="model_name"
-            label="Response synthesizer model"
-          >
-            <Select options={transformModelOptions(data)} />
-          </Form.Item>
-          <RequestModels />
-          <Form.Item<QueryConfiguration>
-            name="top_k"
-            initialValue={queryConfiguration.top_k}
-            label="Maximum number of documents"
-          >
-            <ResponseChunksSlider />
-          </Form.Item>
-        </Form>
-      </Flex>
-    </Modal>
-  );
+const marks: SliderSingleProps["marks"] = {
+  1: "1",
+  10: "10",
 };
 
-export default QueryTimeSettingsModal;
+const ResponseChunksSlider = () => {
+  return <Slider marks={marks} min={1} max={10} />;
+};
+
+export default ResponseChunksSlider;

--- a/ui/src/pages/RagChatTab/State/RagChatContext.tsx
+++ b/ui/src/pages/RagChatTab/State/RagChatContext.tsx
@@ -42,29 +42,27 @@ import { Session } from "src/api/sessionApi.ts";
 import { DataSourceType } from "src/api/dataSourceApi.ts";
 
 export interface RagChatContextType {
-  dataSourceId?: number;
-  excludeKnowledgeBase: boolean;
-  setExcludeKnowledgeBase: Dispatch<SetStateAction<boolean>>;
-  setCurrentQuestion: Dispatch<SetStateAction<string>>;
-  currentQuestion: string;
-  chatHistory: ChatMessageType[];
-  chatHistoryStatus?: "error" | "success" | "pending";
-  dataSourceSize: number | null;
-  dataSourcesStatus?: "error" | "success" | "pending";
   activeSession?: Session;
-  dataSources: DataSourceType[];
+  currentQuestionState: [string, Dispatch<SetStateAction<string>>];
+  chatHistoryQuery: {
+    chatHistory: ChatMessageType[];
+    chatHistoryStatus?: "error" | "success" | "pending";
+  };
+  dataSourcesQuery: {
+    dataSources: DataSourceType[];
+    dataSourcesStatus?: "error" | "success" | "pending";
+  };
+  dataSourceId?: number;
+  dataSourceSize: number | null;
+  excludeKnowledgeBaseState: [boolean, Dispatch<SetStateAction<boolean>>];
 }
 
 export const RagChatContext = createContext<RagChatContextType>({
-  dataSourceId: undefined, // TODO: remove this and have it pulled from active session
   activeSession: undefined,
-  dataSources: [],
-  excludeKnowledgeBase: false,
-  setExcludeKnowledgeBase: () => null,
-  setCurrentQuestion: () => null,
-  currentQuestion: "",
-  chatHistory: [],
+  currentQuestionState: ["", () => null],
+  chatHistoryQuery: { chatHistory: [], chatHistoryStatus: undefined },
+  dataSourcesQuery: { dataSources: [], dataSourcesStatus: undefined },
+  dataSourceId: undefined, // TODO: remove this and have it pulled from active session
   dataSourceSize: null,
-  chatHistoryStatus: undefined,
-  dataSourcesStatus: undefined,
+  excludeKnowledgeBaseState: [false, () => null],
 });

--- a/ui/src/pages/RagChatTab/State/RagChatContext.tsx
+++ b/ui/src/pages/RagChatTab/State/RagChatContext.tsx
@@ -37,14 +37,14 @@
  ******************************************************************************/
 
 import { createContext, Dispatch, SetStateAction } from "react";
-import { ChatMessageType, QueryConfiguration } from "src/api/chatApi.ts";
+import { ChatMessageType } from "src/api/chatApi.ts";
 import { Session } from "src/api/sessionApi.ts";
 import { DataSourceType } from "src/api/dataSourceApi.ts";
 
 export interface RagChatContextType {
   dataSourceId?: number;
-  queryConfiguration: QueryConfiguration;
-  setQueryConfiguration: Dispatch<SetStateAction<QueryConfiguration>>;
+  excludeKnowledgeBase: boolean;
+  setExcludeKnowledgeBase: Dispatch<SetStateAction<boolean>>;
   setCurrentQuestion: Dispatch<SetStateAction<string>>;
   currentQuestion: string;
   chatHistory: ChatMessageType[];
@@ -55,18 +55,12 @@ export interface RagChatContextType {
   dataSources: DataSourceType[];
 }
 
-export const defaultQueryConfig = {
-  top_k: 5,
-  model_name: "",
-  exclude_knowledge_base: false,
-};
-
 export const RagChatContext = createContext<RagChatContextType>({
   dataSourceId: undefined, // TODO: remove this and have it pulled from active session
   activeSession: undefined,
   dataSources: [],
-  queryConfiguration: defaultQueryConfig,
-  setQueryConfiguration: () => null,
+  excludeKnowledgeBase: false,
+  setExcludeKnowledgeBase: () => null,
   setCurrentQuestion: () => null,
   currentQuestion: "",
   chatHistory: [],

--- a/ui/src/pages/RagChatTab/State/RagChatContext.tsx
+++ b/ui/src/pages/RagChatTab/State/RagChatContext.tsx
@@ -52,7 +52,6 @@ export interface RagChatContextType {
     dataSources: DataSourceType[];
     dataSourcesStatus?: "error" | "success" | "pending";
   };
-  dataSourceId?: number;
   dataSourceSize: number | null;
   excludeKnowledgeBaseState: [boolean, Dispatch<SetStateAction<boolean>>];
 }
@@ -62,7 +61,6 @@ export const RagChatContext = createContext<RagChatContextType>({
   currentQuestionState: ["", () => null],
   chatHistoryQuery: { chatHistory: [], chatHistoryStatus: undefined },
   dataSourcesQuery: { dataSources: [], dataSourcesStatus: undefined },
-  dataSourceId: undefined, // TODO: remove this and have it pulled from active session
   dataSourceSize: null,
   excludeKnowledgeBaseState: [false, () => null],
 });


### PR DESCRIPTION
* Each session now can store an inference model as well as the number of response chunks (top k).  
* Remove llama 405b model
* Add cohere R+ model