### PR TITLE
Refetch logic for summaries and fastapi log change

### DIFF
--- a/scripts/startup_app.sh
+++ b/scripts/startup_app.sh
@@ -61,7 +61,7 @@ scripts/startup_java.sh & 2>&1
 
 # start Python backend
 cd llm-service
-uv run fastapi run --host 127.0.0.1 --port 8081 & 2>&1
+uv run fastapi run --reload --host 127.0.0.1 --port 8081 & 2>&1
 
 # wait for the python backend to be ready
 while ! curl --output /dev/null --silent --fail http://localhost:8081/amp-update; do

--- a/ui/src/api/ragDocumentsApi.ts
+++ b/ui/src/api/ragDocumentsApi.ts
@@ -127,7 +127,10 @@ export interface RagDocumentResponseType {
   summaryCreationTimestamp: number | null;
 }
 
-export const useGetRagDocuments = (dataSourceId: string) => {
+export const useGetRagDocuments = (
+  dataSourceId: string,
+  summarizationModel?: string,
+) => {
   return useQuery({
     queryKey: [QueryKeys.getRagDocuments, { dataSourceId }],
     queryFn: () => getRagDocuments(dataSourceId),
@@ -139,10 +142,16 @@ export const useGetRagDocuments = (dataSourceId: string) => {
       const nullTimestampDocuments = data.find(
         (file: RagDocumentResponseType) => file.vectorUploadTimestamp === null,
       );
-      const nullSummaryCreation = data.find(
-        (file: RagDocumentResponseType) =>
-          file.summaryCreationTimestamp === null,
-      );
+
+      let nullSummaryCreation = null;
+
+      if (summarizationModel && summarizationModel.length > 0) {
+        nullSummaryCreation = data.find(
+          (file: RagDocumentResponseType) =>
+            file.summaryCreationTimestamp === null,
+        );
+      }
+
       return nullTimestampDocuments || nullSummaryCreation ? 3000 : false;
     },
   });

--- a/ui/src/pages/DataSources/ManageTab/UploadedFilesHeader.tsx
+++ b/ui/src/pages/DataSources/ManageTab/UploadedFilesHeader.tsx
@@ -36,37 +36,45 @@
  * DATA.
  ******************************************************************************/
 
-import { Layout, Typography } from "antd";
-import DataSourcesTabs from "pages/DataSources/Tabs.tsx";
-import { useQuery } from "@tanstack/react-query";
-import { DataSourceType, getDataSourceById } from "src/api/dataSourceApi.ts";
-import { createContext } from "react";
-import { Route } from "src/routes/_layout/data/_layout-datasources/$dataSourceId";
+import { RagDocumentResponseType } from "src/api/ragDocumentsApi.ts";
+import { Flex, Typography } from "antd";
+import { bytesConversion } from "src/utils/bytesConversion.ts";
+import { CheckCircleOutlined, LoadingOutlined } from "@ant-design/icons";
+import KnowledgeBaseSummary from "pages/DataSources/ManageTab/KnowledgeBaseSummary.tsx";
 
-export const DataSourceContext = createContext<{
-  dataSourceId: string;
-  dataSourceMetaData?: DataSourceType;
-}>({ dataSourceId: "" });
-
-function DataSourceLayout() {
-  const { dataSourceId } = Route.useParams();
-  const { data } = useQuery(getDataSourceById(dataSourceId));
+const UploadedFilesHeader = ({
+  ragDocuments,
+  docsLoading,
+}: {
+  ragDocuments: RagDocumentResponseType[];
+  docsLoading: boolean;
+}) => {
+  const completedIndexing = ragDocuments.filter(
+    (doc) => doc.vectorUploadTimestamp !== null,
+  ).length;
+  const totalSize = ragDocuments.reduce((acc, doc) => acc + doc.sizeInBytes, 0);
 
   return (
-    <Layout
-      style={{
-        alignItems: "center",
-        width: "100%",
-      }}
-    >
-      <Typography.Title level={1}>{data?.name}</Typography.Title>
-      <DataSourceContext.Provider
-        value={{ dataSourceId, dataSourceMetaData: data }}
-      >
-        <DataSourcesTabs />
-      </DataSourceContext.Provider>
-    </Layout>
+    <Flex style={{ width: "100%", marginBottom: 10 }} vertical gap={10}>
+      <Flex flex={1} style={{ width: "100%" }}>
+        <KnowledgeBaseSummary ragDocuments={ragDocuments} />
+      </Flex>
+      <Flex vertical justify="end" align="end">
+        <Typography.Text type="secondary">
+          Total Documents: {ragDocuments.length} (
+          {bytesConversion(totalSize.toString())})
+        </Typography.Text>
+        <Typography.Text type="secondary">
+          Documents indexed: {completedIndexing} / {ragDocuments.length}
+          {docsLoading || ragDocuments.length !== completedIndexing ? (
+            <LoadingOutlined style={{ marginLeft: 5 }} />
+          ) : (
+            <CheckCircleOutlined style={{ marginLeft: 5, color: "green" }} />
+          )}
+        </Typography.Text>
+      </Flex>
+    </Flex>
   );
-}
+};
 
-export default DataSourceLayout;
+export default UploadedFilesHeader;

--- a/ui/src/pages/DataSources/ManageTab/UploadedFilesTable.tsx
+++ b/ui/src/pages/DataSources/ManageTab/UploadedFilesTable.tsx
@@ -58,18 +58,17 @@ import {
   useGetRagDocuments,
 } from "src/api/ragDocumentsApi.ts";
 import { bytesConversion } from "src/utils/bytesConversion.ts";
-import StatsWidget from "pages/DataSources/ManageTab/StatsWidget.tsx";
+import UploadedFilesHeader from "pages/DataSources/ManageTab/UploadedFilesHeader.tsx";
 import AiAssistantIcon from "src/cuix/icons/AiAssistantIcon";
 import DocumentationIcon from "src/cuix/icons/DocumentationIcon";
 import { useGetDocumentSummary } from "src/api/summaryApi.ts";
 import { useContext, useState } from "react";
 import messageQueue from "src/utils/messageQueue.ts";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "src/api/utils.ts";
 import useModal from "src/utils/useModal.ts";
 import { cdlWhite } from "src/cuix/variables.ts";
 import { DataSourceContext } from "pages/DataSources/Layout.tsx";
-import { getDataSourceById } from "src/api/dataSourceApi.ts";
 
 function SummaryPopover({
   dataSourceId,
@@ -210,14 +209,14 @@ const columns = (
 ];
 
 const UploadedFilesTable = () => {
-  const { dataSourceId } = useContext(DataSourceContext);
+  const { dataSourceId, dataSourceMetaData } = useContext(DataSourceContext);
   const [selectedDocument, setSelectedDocument] =
     useState<RagDocumentResponseType>();
   const deleteConfirmationModal = useModal();
   const queryClient = useQueryClient();
-  const getRagDocuments = useGetRagDocuments(dataSourceId);
-  const { data: dataSourceMetaData } = useQuery(
-    getDataSourceById(dataSourceId),
+  const getRagDocuments = useGetRagDocuments(
+    dataSourceId,
+    dataSourceMetaData?.summarizationModel,
   );
   const deleteDocumentMutation = useDeleteDocumentMutation({
     onSuccess: () => {
@@ -264,10 +263,9 @@ const UploadedFilesTable = () => {
 
   return (
     <>
-      <StatsWidget
+      <UploadedFilesHeader
         ragDocuments={ragDocuments}
         docsLoading={docsLoading}
-        dataSourceId={dataSourceId}
       />
       <Table<RagDocumentResponseType>
         loading={docsLoading}


### PR DESCRIPTION
* stop polling for summaries if no summary model
* refetch kb summary if all doc summaries are generated
* add in fastapi change to hopefully get python logs