### PR TITLE
Push MLflow experiment tracking to a reconciler to avoid race conditions

### DIFF
--- a/llm-service/.gitignore
+++ b/llm-service/.gitignore
@@ -167,3 +167,5 @@ cython_debug/
 # Mlflow
 
 mlruns/
+
+reconciler/data/

--- a/llm-service/app/main.py
+++ b/llm-service/app/main.py
@@ -38,6 +38,8 @@
 
 import functools
 import logging
+import os
+import pwd
 import sys
 import time
 from collections.abc import Awaitable, Callable

--- a/llm-service/app/main.py
+++ b/llm-service/app/main.py
@@ -38,8 +38,6 @@
 
 import functools
 import logging
-import os
-import pwd
 import sys
 import time
 from collections.abc import Awaitable, Callable

--- a/llm-service/app/routers/index/data_source/__init__.py
+++ b/llm-service/app/routers/index/data_source/__init__.py
@@ -48,7 +48,7 @@ from ....ai.vector_stores.vector_store import VectorStore
 from ....services import document_storage, models
 from ....services.metadata_apis import data_sources_metadata_api
 from ....services.metadata_apis.data_sources_metadata_api import RagDataSource
-from ....services.mlflow import data_source_record_run
+from ....services.mlflow import data_source_record_run, RagIndexDocumentRequest
 
 logger = logging.getLogger(__name__)
 
@@ -61,18 +61,6 @@ class SummarizeDocumentRequest(BaseModel):
     s3_bucket_name: str
     s3_document_key: str
     original_filename: str
-
-
-class RagIndexDocumentConfiguration(BaseModel):
-    chunk_size: int = 512  # this is llama-index's default
-    chunk_overlap: int = 10  # percentage of tokens in a chunk (chunk_size)
-
-
-class RagIndexDocumentRequest(BaseModel):
-    s3_bucket_name: str
-    s3_document_key: str
-    original_filename: str
-    configuration: RagIndexDocumentConfiguration = RagIndexDocumentConfiguration()
 
 
 class ChunkContentsResponse(BaseModel):

--- a/llm-service/app/routers/index/data_source/__init__.py
+++ b/llm-service/app/routers/index/data_source/__init__.py
@@ -32,6 +32,7 @@ import tempfile
 from http import HTTPStatus
 from typing import Any, Dict, Optional
 
+import mlflow
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi_utils.cbv import cbv
 from llama_index.core.llms import LLM
@@ -129,10 +130,10 @@ class DataSourceController:
         request: RagIndexDocumentRequest,
     ) -> None:
         datasource = data_sources_metadata_api.get_metadata(data_source_id)
-        # mlflow.llama_index.autolog()
+        mlflow.llama_index.autolog()
         self._download_and_index(datasource, doc_id, request)
 
-    # @mlflow.trace(name="download_and_index")
+    @mlflow.trace(name="download_and_index")
     def _download_and_index(
         self, datasource: RagDataSource, doc_id: str, request: RagIndexDocumentRequest
     ) -> None:

--- a/llm-service/app/routers/index/data_source/__init__.py
+++ b/llm-service/app/routers/index/data_source/__init__.py
@@ -32,7 +32,6 @@ import tempfile
 from http import HTTPStatus
 from typing import Any, Dict, Optional
 
-import mlflow
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi_utils.cbv import cbv
 from llama_index.core.llms import LLM
@@ -130,7 +129,7 @@ class DataSourceController:
         request: RagIndexDocumentRequest,
     ) -> None:
         datasource = data_sources_metadata_api.get_metadata(data_source_id)
-        mlflow.llama_index.autolog()
+        # mlflow.llama_index.autolog()
         self._download_and_index(datasource, doc_id, request)
 
     # @mlflow.trace(name="download_and_index")

--- a/llm-service/app/routers/index/data_source/__init__.py
+++ b/llm-service/app/routers/index/data_source/__init__.py
@@ -32,7 +32,6 @@ import tempfile
 from http import HTTPStatus
 from typing import Any, Dict, Optional
 
-import mlflow
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi_utils.cbv import cbv
 from llama_index.core.llms import LLM
@@ -142,10 +141,8 @@ class DataSourceController:
         request: RagIndexDocumentRequest,
     ) -> None:
         datasource = data_sources_metadata_api.get_metadata(data_source_id)
-        mlflow.llama_index.autolog()
         self._download_and_index(datasource, doc_id, request)
 
-    @mlflow.trace(name="download_and_index")
     def _download_and_index(
         self, datasource: RagDataSource, doc_id: str, request: RagIndexDocumentRequest
     ) -> None:

--- a/llm-service/app/routers/index/sessions/__init__.py
+++ b/llm-service/app/routers/index/sessions/__init__.py
@@ -42,14 +42,13 @@ from typing import Annotated
 
 import mlflow
 from fastapi import APIRouter, Cookie
-from mlflow.entities import Experiment, Run
 from pydantic import BaseModel
 
 from .... import exceptions
 from ....rag_types import RagPredictConfiguration
 from ....services.chat import generate_suggested_questions, v2_chat, direct_llm_chat
 from ....services.chat_store import ChatHistoryManager, RagStudioChatMessage
-from ....services.metadata_apis import session_metadata_api
+from ....services.mlflow import rating_mlflow_log_metric, feedback_mlflow_log_table
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/sessions/{session_id}", tags=["Sessions"])
@@ -93,18 +92,7 @@ def rating(
     response_id: str,
     request: ChatResponseRating,
 ) -> ChatResponseRating:
-    session = session_metadata_api.get_session(session_id)
-    experiment: Experiment = mlflow.set_experiment(
-        experiment_name=f"session_{session.name}_{session.id}"
-    )
-    runs: list[Run] = mlflow.search_runs(
-        [experiment.experiment_id],
-        filter_string=f"tags.response_id='{response_id}'",
-        output_format="list",
-    )
-    for run in runs:
-        value: int = 1 if request.rating else -1
-        mlflow.log_metric("rating", value, run_id=run.info.run_id)
+    rating_mlflow_log_metric(request, response_id, session_id)
     return ChatResponseRating(rating=request.rating)
 
 
@@ -121,21 +109,7 @@ def feedback(
     response_id: str,
     request: ChatResponseFeedback,
 ) -> ChatResponseFeedback:
-    session = session_metadata_api.get_session(session_id)
-    experiment: Experiment = mlflow.set_experiment(
-        experiment_name=f"session_{session.name}_{session.id}"
-    )
-    runs: list[Run] = mlflow.search_runs(
-        [experiment.experiment_id],
-        filter_string=f"tags.response_id='{response_id}'",
-        output_format="list",
-    )
-    for run in runs:
-        mlflow.log_table(
-            data={"feedback": request.feedback},
-            artifact_file="feedback.json",
-            run_id=run.info.run_id,
-        )
+    feedback_mlflow_log_table(request, response_id, session_id)
     return ChatResponseFeedback(feedback=request.feedback)
 
 

--- a/llm-service/app/routers/index/sessions/__init__.py
+++ b/llm-service/app/routers/index/sessions/__init__.py
@@ -91,7 +91,7 @@ def rating(
     response_id: str,
     request: ChatResponseRating,
 ) -> ChatResponseRating:
-    rating_mlflow_log_metric(request, response_id, session_id)
+    rating_mlflow_log_metric(request.rating, response_id, session_id)
     return ChatResponseRating(rating=request.rating)
 
 
@@ -108,7 +108,7 @@ def feedback(
     response_id: str,
     request: ChatResponseFeedback,
 ) -> ChatResponseFeedback:
-    feedback_mlflow_log_table(request, response_id, session_id)
+    feedback_mlflow_log_table(request.feedback, response_id, session_id)
     return ChatResponseFeedback(feedback=request.feedback)
 
 

--- a/llm-service/app/routers/index/sessions/__init__.py
+++ b/llm-service/app/routers/index/sessions/__init__.py
@@ -141,7 +141,6 @@ def chat(
     _basusertoken: Annotated[str | None, Cookie()] = None,
 ) -> RagStudioChatMessage:
     user_name = parse_jwt_cookie(_basusertoken)
-    # mlflow.llama_index.autolog()
 
     configuration = request.configuration or RagPredictConfiguration()
     if configuration.exclude_knowledge_base:

--- a/llm-service/app/routers/index/sessions/__init__.py
+++ b/llm-service/app/routers/index/sessions/__init__.py
@@ -40,7 +40,6 @@ import json
 import logging
 from typing import Annotated
 
-import mlflow
 from fastapi import APIRouter, Cookie
 from pydantic import BaseModel
 
@@ -142,7 +141,7 @@ def chat(
     _basusertoken: Annotated[str | None, Cookie()] = None,
 ) -> RagStudioChatMessage:
     user_name = parse_jwt_cookie(_basusertoken)
-    mlflow.llama_index.autolog()
+    # mlflow.llama_index.autolog()
 
     configuration = request.configuration or RagPredictConfiguration()
     if configuration.exclude_knowledge_base:

--- a/llm-service/app/services/chat.py
+++ b/llm-service/app/services/chat.py
@@ -39,7 +39,6 @@ import time
 import uuid
 from typing import List, Iterable
 
-import mlflow
 from fastapi import HTTPException
 from llama_index.core.base.llms.types import MessageRole
 from llama_index.core.chat_engine.types import AgentChatResponse
@@ -85,7 +84,6 @@ def v2_chat(
     return new_chat_message
 
 
-@mlflow.trace(name="v2_chat")
 def _run_chat(
     session: Session,
     response_id: str,

--- a/llm-service/app/services/chat.py
+++ b/llm-service/app/services/chat.py
@@ -39,7 +39,7 @@ import time
 import uuid
 from typing import List, Iterable
 
-# import mlflow
+import mlflow
 from fastapi import HTTPException
 from llama_index.core.base.llms.types import MessageRole
 from llama_index.core.chat_engine.types import AgentChatResponse
@@ -85,7 +85,7 @@ def v2_chat(
     return new_chat_message
 
 
-# @mlflow.trace(name="v2_chat")
+@mlflow.trace(name="v2_chat")
 def _run_chat(
     session: Session,
     response_id: str,

--- a/llm-service/app/services/mlflow/__init__.py
+++ b/llm-service/app/services/mlflow/__init__.py
@@ -36,13 +36,14 @@
 #  DATA.
 #
 import json
+import os
 import re
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 import mlflow
-from mlflow import MlflowClient
-from mlflow.entities import Experiment, Param, Metric, RunTag, Run
+from mlflow.entities import Experiment, Run
 from pydantic import BaseModel
 
 from app.services.chat_store import RagStudioChatMessage, RagPredictSourceNode
@@ -54,30 +55,30 @@ from app.services.query.query_configuration import QueryConfiguration
 # mypy: disable-error-code="no-untyped-call"
 
 
-def chat_log_ml_flow_table(message: RagStudioChatMessage) -> None:
+def chat_log_ml_flow_table(message: RagStudioChatMessage) -> dict[str, Any]:
     source_nodes: list[RagPredictSourceNode] = message.source_nodes
 
     query = message.rag_message.user
     response = message.rag_message.assistant
 
     flattened_nodes = [node.model_dump() for node in source_nodes]
-    mlflow.log_table(
-        {
+    return {
+        "data": {
             "response_id": message.id,
-            "node_id": map(lambda x: x.get("node_id"), flattened_nodes),
-            "doc_id": map(lambda x: x.get("doc_id"), flattened_nodes),
-            "source_file_name": map(
-                lambda x: x.get("source_file_name"), flattened_nodes
+            "node_id": list(map(lambda x: x.get("node_id"), flattened_nodes)),
+            "doc_id": list(map(lambda x: x.get("doc_id"), flattened_nodes)),
+            "source_file_name": list(
+                map(lambda x: x.get("source_file_name"), flattened_nodes)
             ),
-            "score": map(lambda x: x.get("score"), flattened_nodes),
+            "score": list(map(lambda x: x.get("score"), flattened_nodes)),
             "query": query,
             "response": response,
             "input_word_count": len(re.findall(r"\w+", query)),
             "output_word_count": len(re.findall(r"\w+", response)),
             "condensed_question": message.condensed_question,
         },
-        artifact_file="response_details.json",
-    )
+        "artifact_file": "response_details.json",
+    }
 
 
 def chat_log_ml_flow_params(
@@ -111,64 +112,51 @@ def record_rag_mlflow_run(
     session: Session,
     user_name: str,
 ) -> None:
-    experiment: Experiment = mlflow.set_experiment(
-        experiment_name=f"session_{session.name}_{session.id}"
-    )
+    params = chat_log_ml_flow_params(session, query_configuration, user_name)
+    source_nodes: list[RagPredictSourceNode] = new_chat_message.source_nodes
+    metrics: dict[str, Any] = {
+        "source_nodes_count": len(source_nodes),
+        "max_score": (source_nodes[0].score if source_nodes else 0.0),
+        **{
+            evaluation.name: evaluation.value
+            for evaluation in new_chat_message.evaluations
+        },
+    }
 
-    # mlflow.set_experiment_tag("session_id", session.id)
-    with mlflow.start_run(
-        experiment_id=experiment.experiment_id, run_name=f"{response_id}"
-    ) as run:
-        client = MlflowClient()
-        params = chat_log_ml_flow_params(session, query_configuration, user_name)
-        source_nodes: list[RagPredictSourceNode] = new_chat_message.source_nodes
-        metrics: dict[str, Any] = {
-            "source_nodes_count": len(source_nodes),
-            "max_score": (source_nodes[0].score if source_nodes else 0.0),
-            **{
-                evaluation.name: evaluation.value
-                for evaluation in new_chat_message.evaluations
+    write_mlflow_run_json(
+        experiment_name=f"session_{session.name}_{session.id}",
+        run_name=f"{response_id}",
+        data={
+            "params": params,
+            "tags": {
+                "response_id": response_id,
             },
-        }
-        client.log_batch(
-            run.info.run_id,
-            tags=[RunTag("response_id", response_id)],
-            params=[Param(key=key, value=value) for key, value in params.items()],
-            metrics=[
-                Metric(
-                    key=key,
-                    value=value,
-                    timestamp=int(new_chat_message.timestamp),
-                    step=0,
-                )
-                for key, value in metrics.items()
-            ],
-        )
-        chat_log_ml_flow_table(new_chat_message)
+            "metrics": metrics,
+            "table": chat_log_ml_flow_table(new_chat_message),
+        },
+    )
 
 
 def record_direct_llm_mlflow_run(
     response_id: str, session: Session, user_name: str
 ) -> None:
-    experiment = mlflow.set_experiment(
-        experiment_name=f"session_{session.name}_{session.id}"
+    write_mlflow_run_json(
+        f"session_{session.name}_{session.id}",
+        f"{response_id}",
+        {
+            "params": {
+                "inference_model": session.inference_model,
+                "exclude_knowledge_base": True,
+                "session_id": session.id,
+                "data_source_ids": session.data_source_ids,
+                "user_name": user_name,
+            },
+            "tags": {
+                "response_id": response_id,
+                "direct_llm": True,
+            },
+        },
     )
-    with mlflow.start_run(
-        experiment_id=experiment.experiment_id, run_name=f"{response_id}"
-    ) as run:
-        params: Sequence[Param] = [
-            Param("inference_model", session.inference_model),
-            Param("exclude_knowledge_base", True),
-            Param("session_id", session.id),
-            Param("data_source_ids", session.data_source_ids),
-            Param("user_name", user_name),
-        ]
-        client = MlflowClient()
-        client.log_batch(
-            run.info.run_id,
-            tags=[RunTag("response_id", response_id), RunTag("direct_llm", True)],
-            params=params,
-        )
 
 
 class RagIndexDocumentConfiguration(BaseModel):
@@ -187,10 +175,14 @@ def write_mlflow_run_json(experiment_name: str, run_name: str, data: dict[str, A
     contents = {
         "experiment_name": experiment_name,
         "run_name": run_name,
-        "data": data,
         "status": "pending",
+        "created_at": datetime.now().timestamp(),
+        **data,
     }
-    with open(f"{experiment_name}-{run_name}.json", "w") as f:
+    with open(
+        f"{os.environ['MLFLOW_RECONCILER_DATA_PATH']}/{experiment_name}-{run_name}.json",
+        "w",
+    ) as f:
         json.dump(contents, f)
 
 

--- a/llm-service/app/services/mlflow/__init__.py
+++ b/llm-service/app/services/mlflow/__init__.py
@@ -46,6 +46,7 @@ import mlflow
 from mlflow.entities import Experiment, Run
 from pydantic import BaseModel
 
+from app.routers.index.sessions import ChatResponseRating, ChatResponseFeedback
 from app.services.chat_store import RagStudioChatMessage, RagPredictSourceNode
 from app.services.metadata_apis import data_sources_metadata_api, session_metadata_api
 from app.services.metadata_apis.data_sources_metadata_api import RagDataSource
@@ -171,7 +172,9 @@ class RagIndexDocumentRequest(BaseModel):
     configuration: RagIndexDocumentConfiguration = RagIndexDocumentConfiguration()
 
 
-def write_mlflow_run_json(experiment_name: str, run_name: str, data: dict[str, Any]):
+def write_mlflow_run_json(
+    experiment_name: str, run_name: str, data: dict[str, Any]
+) -> None:
     contents = {
         "experiment_name": experiment_name,
         "run_name": run_name,
@@ -210,7 +213,9 @@ def data_source_record_run(
     )
 
 
-def rating_mlflow_log_metric(request, response_id, session_id):
+def rating_mlflow_log_metric(
+    request: ChatResponseRating, response_id: str, session_id: int
+) -> None:
     session = session_metadata_api.get_session(session_id)
     experiment: Experiment = mlflow.set_experiment(
         experiment_name=f"session_{session.name}_{session.id}"
@@ -226,7 +231,9 @@ def rating_mlflow_log_metric(request, response_id, session_id):
         mlflow.log_metric("rating", value, run_id=run.info.run_id)
 
 
-def feedback_mlflow_log_table(request, response_id, session_id):
+def feedback_mlflow_log_table(
+    request: ChatResponseFeedback, response_id: str, session_id: int
+) -> None:
     session = session_metadata_api.get_session(session_id)
     experiment: Experiment = mlflow.set_experiment(
         experiment_name=f"session_{session.name}_{session.id}"

--- a/llm-service/app/services/mlflow/__init__.py
+++ b/llm-service/app/services/mlflow/__init__.py
@@ -1,0 +1,151 @@
+#
+#  CLOUDERA APPLIED MACHINE LEARNING PROTOTYPE (AMP)
+#  (C) Cloudera, Inc. 2024
+#  All rights reserved.
+#
+#  Applicable Open Source License: Apache 2.0
+#
+#  NOTE: Cloudera open source products are modular software products
+#  made up of hundreds of individual components, each of which was
+#  individually copyrighted.  Each Cloudera open source product is a
+#  collective work under U.S. Copyright Law. Your license to use the
+#  collective work is as provided in your written agreement with
+#  Cloudera.  Used apart from the collective work, this file is
+#  licensed for your use pursuant to the open source license
+#  identified above.
+#
+#  This code is provided to you pursuant a written agreement with
+#  (i) Cloudera, Inc. or (ii) a third-party authorized to distribute
+#  this code. If you do not have a written agreement with Cloudera nor
+#  with an authorized and properly licensed third party, you do not
+#  have any rights to access nor to use this code.
+#
+#  Absent a written agreement with Cloudera, Inc. ("Cloudera") to the
+#  contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
+#  KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
+#  WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
+#  IMPLIED WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE; (C) CLOUDERA IS NOT LIABLE TO YOU,
+#  AND WILL NOT DEFEND, INDEMNIFY, NOR HOLD YOU HARMLESS FOR ANY CLAIMS
+#  ARISING FROM OR RELATED TO THE CODE; AND (D)WITH RESPECT TO YOUR EXERCISE
+#  OF ANY RIGHTS GRANTED TO YOU FOR THE CODE, CLOUDERA IS NOT LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR
+#  CONSEQUENTIAL DAMAGES INCLUDING, BUT NOT LIMITED TO, DAMAGES
+#  RELATED TO LOST REVENUE, LOST PROFITS, LOSS OF INCOME, LOSS OF
+#  BUSINESS ADVANTAGE OR UNAVAILABILITY, OR LOSS OR CORRUPTION OF
+#  DATA.
+#
+
+import re
+from typing import Any
+
+import mlflow
+from mlflow import MlflowClient
+from mlflow.entities import Experiment
+
+from app.services.chat_store import RagStudioChatMessage, RagPredictSourceNode
+from app.services.metadata_apis import data_sources_metadata_api
+from app.services.metadata_apis.session_metadata_api import Session
+from app.services.query.query_configuration import QueryConfiguration
+
+
+def chat_log_ml_flow_table(message: RagStudioChatMessage) -> None:
+    source_nodes: list[RagPredictSourceNode] = message.source_nodes
+
+    query = message.rag_message.user
+    response = message.rag_message.assistant
+
+    flattened_nodes = [node.model_dump() for node in source_nodes]
+    mlflow.log_table(
+        {
+            "response_id": message.id,
+            "node_id": map(lambda x: x.get("node_id"), flattened_nodes),
+            "doc_id": map(lambda x: x.get("doc_id"), flattened_nodes),
+            "source_file_name": map(
+                lambda x: x.get("source_file_name"), flattened_nodes
+            ),
+            "score": map(lambda x: x.get("score"), flattened_nodes),
+            "query": query,
+            "response": response,
+            "input_word_count": len(re.findall(r"\w+", query)),
+            "output_word_count": len(re.findall(r"\w+", response)),
+            "condensed_question": message.condensed_question,
+        },
+        artifact_file="response_details.json",
+    )
+
+
+def chat_log_ml_flow_params(
+    session: Session, query_configuration: QueryConfiguration, user_name: str
+) -> dict[str, Any]:
+    data_source_metadata = data_sources_metadata_api.get_metadata(
+        session.data_source_ids[0]
+    )
+    return {
+        "top_k": query_configuration.top_k,
+        "inference_model": query_configuration.model_name,
+        "rerank_model_name": query_configuration.rerank_model_name,
+        "exclude_knowledge_base": query_configuration.exclude_knowledge_base,
+        "use_question_condensing": query_configuration.use_question_condensing,
+        "use_hyde": query_configuration.use_hyde,
+        "use_summary_filter": query_configuration.use_summary_filter,
+        "session_id": session.id,
+        "data_source_ids": session.data_source_ids,
+        "user_name": user_name,
+        "embedding_model": data_source_metadata.embedding_model,
+        "chunk_size": data_source_metadata.chunk_size,
+        "summarization_model": data_source_metadata.summarization_model,
+        "chunk_overlap_percent": data_source_metadata.chunk_overlap_percent,
+    }
+
+
+def record_rag_mlflow_run(
+    new_chat_message, query_configuration, response_id, session, user_name
+):
+    experiment: Experiment = mlflow.set_experiment(
+        experiment_name=f"session_{session.name}_{session.id}"
+    )
+
+    # mlflow.set_experiment_tag("session_id", session.id)
+    run = mlflow.start_run(
+        experiment_id=experiment.experiment_id, run_name=f"{response_id}"
+    )
+    client = MlflowClient()
+    params = chat_log_ml_flow_params(session, query_configuration, user_name)
+    source_nodes: list[RagPredictSourceNode] = new_chat_message.source_nodes
+    metrics = {
+        "source_nodes_count": len(source_nodes),
+        "max_score": (source_nodes[0].score if source_nodes else 0.0),
+        **{
+            evaluation.name: evaluation.value
+            for evaluation in new_chat_message.evaluations
+        },
+    }
+    client.log_batch(
+        run.info.run_id,
+        tags={"response_id": response_id},
+        params=params,
+        metrics=metrics,
+    )
+    chat_log_ml_flow_table(new_chat_message)
+
+
+def record_direct_llm_mlflow_run(response_id, session, user_name):
+    experiment = mlflow.set_experiment(
+        experiment_name=f"session_{session.name}_{session.id}"
+    )
+    run = mlflow.start_run(
+        experiment_id=experiment.experiment_id, run_name=f"{response_id}"
+    )
+    client = MlflowClient()
+    client.log_batch(
+        run.info.run_id,
+        tags={"response_id": response_id, "direct_llm": True},
+        params={
+            "inference_model": session.inference_model,
+            "exclude_knowledge_base": True,
+            "session_id": session.id,
+            "data_source_ids": session.data_source_ids,
+            "user_name": user_name,
+        },
+    )

--- a/llm-service/app/services/mlflow/__init__.py
+++ b/llm-service/app/services/mlflow/__init__.py
@@ -43,8 +43,8 @@ from typing import Any
 import mlflow
 from mlflow import MlflowClient
 from mlflow.entities import Experiment
+from pydantic import BaseModel
 
-from app.routers.index.data_source import RagIndexDocumentRequest
 from app.services.chat_store import RagStudioChatMessage, RagPredictSourceNode
 from app.services.metadata_apis import data_sources_metadata_api
 from app.services.metadata_apis.data_sources_metadata_api import RagDataSource
@@ -158,6 +158,18 @@ def record_direct_llm_mlflow_run(
             "user_name": user_name,
         },
     )
+
+
+class RagIndexDocumentConfiguration(BaseModel):
+    chunk_size: int = 512  # this is llama-index's default
+    chunk_overlap: int = 10  # percentage of tokens in a chunk (chunk_size)
+
+
+class RagIndexDocumentRequest(BaseModel):
+    s3_bucket_name: str
+    s3_document_key: str
+    original_filename: str
+    configuration: RagIndexDocumentConfiguration = RagIndexDocumentConfiguration()
 
 
 def data_source_record_run(

--- a/llm-service/app/services/mlflow/__init__.py
+++ b/llm-service/app/services/mlflow/__init__.py
@@ -39,16 +39,13 @@ import json
 import os
 import re
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 
 import mlflow
 from mlflow.entities import Experiment, Run
-from pydantic import BaseModel
 
 from app.services.chat_store import RagStudioChatMessage, RagPredictSourceNode
 from app.services.metadata_apis import data_sources_metadata_api, session_metadata_api
-from app.services.metadata_apis.data_sources_metadata_api import RagDataSource
 from app.services.metadata_apis.session_metadata_api import Session
 from app.services.query.query_configuration import QueryConfiguration
 

--- a/llm-service/app/services/mlflow/__init__.py
+++ b/llm-service/app/services/mlflow/__init__.py
@@ -46,7 +46,6 @@ import mlflow
 from mlflow.entities import Experiment, Run
 from pydantic import BaseModel
 
-from app.routers.index.sessions import ChatResponseRating, ChatResponseFeedback
 from app.services.chat_store import RagStudioChatMessage, RagPredictSourceNode
 from app.services.metadata_apis import data_sources_metadata_api, session_metadata_api
 from app.services.metadata_apis.data_sources_metadata_api import RagDataSource
@@ -213,9 +212,7 @@ def data_source_record_run(
     )
 
 
-def rating_mlflow_log_metric(
-    request: ChatResponseRating, response_id: str, session_id: int
-) -> None:
+def rating_mlflow_log_metric(rating: bool, response_id: str, session_id: int) -> None:
     session = session_metadata_api.get_session(session_id)
     experiment: Experiment = mlflow.set_experiment(
         experiment_name=f"session_{session.name}_{session.id}"
@@ -227,13 +224,11 @@ def rating_mlflow_log_metric(
     )
 
     for run in runs:
-        value: int = 1 if request.rating else -1
+        value: int = 1 if rating else -1
         mlflow.log_metric("rating", value, run_id=run.info.run_id)
 
 
-def feedback_mlflow_log_table(
-    request: ChatResponseFeedback, response_id: str, session_id: int
-) -> None:
+def feedback_mlflow_log_table(feedback: str, response_id: str, session_id: int) -> None:
     session = session_metadata_api.get_session(session_id)
     experiment: Experiment = mlflow.set_experiment(
         experiment_name=f"session_{session.name}_{session.id}"
@@ -245,7 +240,7 @@ def feedback_mlflow_log_table(
     )
     for run in runs:
         mlflow.log_table(
-            data={"feedback": request.feedback},
+            data={"feedback": feedback},
             artifact_file="feedback.json",
             run_id=run.info.run_id,
         )

--- a/llm-service/app/services/mlflow/__init__.py
+++ b/llm-service/app/services/mlflow/__init__.py
@@ -159,18 +159,6 @@ def record_direct_llm_mlflow_run(
     )
 
 
-class RagIndexDocumentConfiguration(BaseModel):
-    chunk_size: int = 512  # this is llama-index's default
-    chunk_overlap: int = 10  # percentage of tokens in a chunk (chunk_size)
-
-
-class RagIndexDocumentRequest(BaseModel):
-    s3_bucket_name: str
-    s3_document_key: str
-    original_filename: str
-    configuration: RagIndexDocumentConfiguration = RagIndexDocumentConfiguration()
-
-
 def write_mlflow_run_json(
     experiment_name: str, run_name: str, data: dict[str, Any]
 ) -> None:
@@ -186,30 +174,6 @@ def write_mlflow_run_json(
         "w",
     ) as f:
         json.dump(contents, f)
-
-
-def data_source_record_run(
-    datasource: RagDataSource,
-    doc_id: str,
-    file_path: Path,
-    request: RagIndexDocumentRequest,
-) -> None:
-
-    write_mlflow_run_json(
-        f"datasource_{datasource.name}_{datasource.id}",
-        f"doc_{doc_id}",
-        {
-            "params": {
-                "data_source_id": str(datasource.id),
-                "embedding_model": datasource.embedding_model,
-                "summarization_model": datasource.summarization_model,
-                "chunk_size": str(request.configuration.chunk_size),
-                "chunk_overlap": str(request.configuration.chunk_overlap),
-                "file_name": request.original_filename,
-                "file_size_bytes": str(file_path.stat().st_size),
-            }
-        },
-    )
 
 
 def rating_mlflow_log_metric(rating: bool, response_id: str, session_id: int) -> None:

--- a/llm-service/app/tests/conftest.py
+++ b/llm-service/app/tests/conftest.py
@@ -83,6 +83,15 @@ def use_local_storage(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("S3_RAG_DOCUMENT_BUCKET", "")
 
 
+@pytest.fixture(autouse=True)
+def use_mlflow_reconciler_data_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    mlflow_dir = tmp_path / "mlflow-run-data"
+    mlflow_dir.mkdir()
+    monkeypatch.setenv("MLFLOW_RECONCILER_DATA_PATH", str(mlflow_dir))
+
+
 @pytest.fixture
 def document_id(index_document_request_body: dict[str, Any]) -> str:
     return cast(str, index_document_request_body["s3_document_key"].split("/")[-1])

--- a/llm-service/reconciler/mlflow_reconciler.py
+++ b/llm-service/reconciler/mlflow_reconciler.py
@@ -1,0 +1,184 @@
+"""
+Reconciler script to process io request pairs.
+"""
+
+#
+#  CLOUDERA APPLIED MACHINE LEARNING PROTOTYPE (AMP)
+#  (C) Cloudera, Inc. 2024
+#  All rights reserved.
+#
+#  Applicable Open Source License: Apache 2.0
+#
+#  NOTE: Cloudera open source products are modular software products
+#  made up of hundreds of individual components, each of which was
+#  individually copyrighted.  Each Cloudera open source product is a
+#  collective work under U.S. Copyright Law. Your license to use the
+#  collective work is as provided in your written agreement with
+#  Cloudera.  Used apart from the collective work, this file is
+#  licensed for your use pursuant to the open source license
+#  identified above.
+#
+#  This code is provided to you pursuant a written agreement with
+#  (i) Cloudera, Inc. or (ii) a third-party authorized to distribute
+#  this code. If you do not have a written agreement with Cloudera nor
+#  with an authorized and properly licensed third party, you do not
+#  have any rights to access nor to use this code.
+#
+#  Absent a written agreement with Cloudera, Inc. ("Cloudera") to the
+#  contrary, A) CLOUDERA PROVIDES THIS CODE TO YOU WITHOUT WARRANTIES OF ANY
+#  KIND; (B) CLOUDERA DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED
+#  WARRANTIES WITH RESPECT TO THIS CODE, INCLUDING BUT NOT LIMITED TO
+#  IMPLIED WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE; (C) CLOUDERA IS NOT LIABLE TO YOU,
+#  AND WILL NOT DEFEND, INDEMNIFY, NOR HOLD YOU HARMLESS FOR ANY CLAIMS
+#  ARISING FROM OR RELATED TO THE CODE; AND (D)WITH RESPECT TO YOUR EXERCISE
+#  OF ANY RIGHTS GRANTED TO YOU FOR THE CODE, CLOUDERA IS NOT LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR
+#  CONSEQUENTIAL DAMAGES INCLUDING, BUT NOT LIMITED TO, DAMAGES
+#  RELATED TO LOST REVENUE, LOST PROFITS, LOSS OF INCOME, LOSS OF
+#  BUSINESS ADVANTAGE OR UNAVAILABILITY, OR LOSS OR CORRUPTION OF
+#  DATA.
+#
+
+import os
+import json
+import logging
+import sys
+import time
+import threading
+from pathlib import Path
+import argparse
+import asyncio
+from typing import Any, Literal
+
+import mlflow
+from mlflow.entities import Experiment
+from pydantic import BaseModel
+from uvicorn.logging import DefaultFormatter
+
+# Configure logging
+logger = logging.getLogger(__name__)
+formatter = DefaultFormatter("%(levelprefix)s %(message)s")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(formatter)
+
+logger.addHandler(handler)
+
+
+class MlflowTable(BaseModel):
+    data: dict[str, Any]
+    artifact_file: str
+    run_id: str
+
+
+class MlflowRunData(BaseModel):
+    experiment_name: str
+    run_name: str
+    tags: dict[str, Any]
+    metrics: dict[str, int]
+    params: dict[str, Any]
+    table: MlflowTable
+
+
+def evaluate_json_data(data: MlflowRunData) -> Literal["success", "failed", None]:
+
+    if data["status"] == "success":
+        return None
+
+    if data["status"] == "pending":
+        experiment: Experiment = mlflow.set_experiment(
+            experiment_name=data["experiment_name"]
+        )
+        with mlflow.start_run(
+            experiment_id=experiment.experiment_id, run_name=data["run_name"]
+        ):
+            mlflow.log_params(data["params"])
+            mlflow.log_metrics(data["metrics"])
+            mlflow.set_tags(data["tags"])
+            mlflow.log_table(data["table"].data, data["table"].artifact_file)
+            return "success"
+
+    return "failed"
+
+
+async def process_io_pair(file_path, processing_function):
+    """Callback function to process a io saved in a file."""
+    with open(file_path, "r") as f:
+        data = json.load(f)
+    # Process io pair
+    status = await processing_function(data)
+    # save the response
+    if status is not None:
+        data["status"] = status
+        with open(file_path, "w") as f:
+            json.dump(data, f, indent=2)
+    if status == "pending":
+        logger.info(
+            "MLFlow experiment and run IDs set for i/o pair: %s. Queued for evaluation.",
+            file_path,
+        )
+        return
+    if status == "failed":
+        logger.error("Failed to process i/o pair: %s. Will retry.", file_path)
+        return
+
+
+def background_worker(directory, processing_function):
+    """Background thread function to process files."""
+    if not isinstance(directory, Path):
+        directory = Path(directory)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    while True:
+        files_to_process = [
+            file_path
+            for file_path in directory.iterdir()
+            if file_path.is_file() and file_path.suffix == ".json"
+        ]
+        for file_path in files_to_process:
+            try:
+                loop.run_until_complete(
+                    process_io_pair(
+                        file_path=file_path, processing_function=processing_function
+                    )
+                )
+            except Exception as e:
+                logger.error("Error processing file %s: %s", file_path, e)
+        time.sleep(15)
+
+
+# Start background worker thread
+def start_background_worker(directory, processing_function):
+    """Start the background worker thread."""
+    if not isinstance(directory, Path):
+        directory = Path(directory)
+    worker_thread = threading.Thread(
+        target=background_worker, args=(directory, processing_function), daemon=True
+    )
+    worker_thread.start()
+
+
+if __name__ == "__main__":
+    # Directory to save JSON files
+    # Argument parsing to get the data directory
+    parser = argparse.ArgumentParser(
+        description="Reconciler script to process io request pairs."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default=os.path.join("data", "responses"),
+        help="Directory to save JSON files",
+    )
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    data_dir.mkdir(exist_ok=True)
+    start_background_worker(data_dir, evaluate_json_data)
+    try:
+        while True:
+            logger.info("Reconciler looking for i/o pairs in %s...", data_dir)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")

--- a/llm-service/reconciler/mlflow_reconciler.py
+++ b/llm-service/reconciler/mlflow_reconciler.py
@@ -109,13 +109,13 @@ async def evaluate_json_data(data: MlflowRunData) -> Literal["success", "failed"
         with mlflow.start_run(
             experiment_id=experiment.experiment_id, run_name=data["run_name"]
         ):
-            if "tags" in data and data["tags"] is not None:
+            if "tags" in data:
                 mlflow.set_tags(data["tags"])
-            if "params" in data and data["params"] is not None:
+            if "params" in data:
                 mlflow.log_params(data["params"])
-            if "metrics" in data and data["metrics"] is not None:
+            if "metrics" in data:
                 mlflow.log_metrics(data["metrics"])
-            if "table" in data and data["table"] is not None:
+            if "table" in data:
                 mlflow.log_table(**data["table"])
             return "success"
 

--- a/llm-service/reconciler/mlflow_reconciler.py
+++ b/llm-service/reconciler/mlflow_reconciler.py
@@ -106,18 +106,17 @@ async def evaluate_json_data(data: MlflowRunData) -> Literal["success", "failed"
         experiment: Experiment = mlflow.set_experiment(
             experiment_name=data["experiment_name"]
         )
-        print(data)
         with mlflow.start_run(
             experiment_id=experiment.experiment_id, run_name=data["run_name"]
         ):
-            if "tags" in data:
+            if "tags" in data and data["tags"] is not None:
                 mlflow.set_tags(data["tags"])
-            if "params" in data:
+            if "params" in data and data["params"] is not None:
                 mlflow.log_params(data["params"])
-            if "metrics" in data:
+            if "metrics" in data and data["metrics"] is not None:
                 mlflow.log_metrics(data["metrics"])
-            if "table" in data:
-                mlflow.log_table(data["table"].data, data["table"].artifact_file)
+            if "table" in data and data["table"] is not None:
+                mlflow.log_table(**data["table"])
             return "success"
 
     return "failed"

--- a/llm-service/reconciler/mlflow_reconciler.py
+++ b/llm-service/reconciler/mlflow_reconciler.py
@@ -96,7 +96,7 @@ class MlflowRunData(BaseModel):
     experiment_name: str
     run_name: str
     tags: Optional[dict[str, Any]] = None
-    metrics: Optional[dict[str, int]] = None
+    metrics: Optional[dict[str, float]] = None
     params: Optional[dict[str, Any]] = None
     table: Optional[MlflowTable] = None
     status: MlflowRunStatus
@@ -121,7 +121,9 @@ async def evaluate_json_data(data: MlflowRunData) -> Optional[MlflowRunStatus]:
             if data.metrics:
                 mlflow.log_metrics(data.metrics)
             if data.table:
-                mlflow.log_table(**data.table)
+                mlflow.log_table(
+                    data=data.table.data, artifact_file=data.table.artifact_file
+                )
             return "success"
 
     return "failed"

--- a/local-dev.sh
+++ b/local-dev.sh
@@ -70,12 +70,11 @@ if [ -z "$USE_SYSTEM_UV" ]; then
   python -m pip install uv
 fi
 uv sync
-
-mkdir -p $MLFLOW_RECONCILER_DATA_PATH
 uv run pytest -sxvvra app
 
 uv run mlflow ui &
 
+mkdir -p $MLFLOW_RECONCILER_DATA_PATH
 uv run fastapi dev --port=8081 &
 
 # wait for the python backend to be ready

--- a/local-dev.sh
+++ b/local-dev.sh
@@ -42,6 +42,7 @@ set -a && source .env && set +a
 python3.12 scripts/validator/validate_env.py
 
 export RAG_DATABASES_DIR=$(pwd)/databases
+export MLFLOW_RECONCILER_DATA_PATH=$(pwd)/llm-service/reconciler/data
 
 cleanup() {
     # kill all processes whose parent is this process
@@ -80,6 +81,9 @@ while ! curl --output /dev/null --silent --fail http://localhost:8081/amp-update
     echo "Waiting for the Python backend to be ready..."
     sleep 4
 done
+
+# start mlflow reconciler
+uv run reconciler/mlflow_reconciler.py &
 
 # start up the jarva
 cd ../backend

--- a/local-dev.sh
+++ b/local-dev.sh
@@ -70,6 +70,8 @@ if [ -z "$USE_SYSTEM_UV" ]; then
   python -m pip install uv
 fi
 uv sync
+
+mkdir -p $MLFLOW_RECONCILER_DATA_PATH
 uv run pytest -sxvvra app
 
 uv run mlflow ui &

--- a/scripts/startup_app.sh
+++ b/scripts/startup_app.sh
@@ -55,6 +55,7 @@ export RAG_DATABASES_DIR=$(pwd)/databases
 export LLM_SERVICE_URL="http://localhost:8081"
 export API_URL="http://localhost:8080"
 export MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR=false
+export MLFLOW_RECONCILER_DATA_PATH=$(pwd)/llm-service/reconciler/data
 
 # start Qdrant vector DB
 qdrant/qdrant & 2>&1
@@ -71,6 +72,9 @@ while ! curl --output /dev/null --silent --fail http://localhost:8081/amp-update
     echo "Waiting for the Python backend to be ready..."
     sleep 4
 done
+
+# start mlflow reconciler
+uv run reconciler/mlflow_reconciler.py &
 
 # start Node production server
 

--- a/scripts/startup_app.sh
+++ b/scripts/startup_app.sh
@@ -65,6 +65,7 @@ scripts/startup_java.sh & 2>&1
 
 # start Python backend
 cd llm-service
+mkdir -p $MLFLOW_RECONCILER_DATA_PATH
 uv run fastapi run --reload --host 127.0.0.1 --port 8081 & 2>&1
 
 # wait for the python backend to be ready


### PR DESCRIPTION
(tl;dr of [this Slack message](https://cloudera.slack.com/archives/C07EU376GS0/p1739926409050699?thread_ts=1739894220.464289&cid=C07EU376GS0))

RAG Studio tracks session metrics (https://github.com/cloudera/CML_AMP_RAG_Studio/pull/124) and data source metrics (https://github.com/cloudera/CML_AMP_RAG_Studio/pull/125) in their own experiments. However, CML's MLflow tracking store relies on global environmental state, and makes it impossible for us to run multiple MLflow experiments in parallel in CDSW.

So to keep RAG Studio's ability to serve asynchronous requests, we're pushing MLflow experiment tracking operations to a reconciler that can process one experiment run at a time on the side—without blocking the server.