### PR TITLE
Add CDP_TOKEN_OVERRIDE to env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ USE_SYSTEM_UV=true
 
 # set this to true to enable enhanced pdf processing with docling
 USE_ENHANCED_PDF_PROCESSING=false
+
+# override for project CDP_TOKEN
+CDP_TOKEN_OVERRIDE=

--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -34,6 +34,10 @@ environment_variables:
         default: ""
         description: "The domain of the CAII service. Setting this will enable CAII as the sole source for both inference and embedding models."
         required: false
+    CDP_TOKEN_OVERRIDE:
+      default: ""
+      description: "Providing this will override the default project CDP_TOKEN."
+      required: false
 
 
 runtimes:

--- a/llm-service/app/services/caii/utils.py
+++ b/llm-service/app/services/caii/utils.py
@@ -47,8 +47,8 @@ def build_auth_headers() -> Dict[str, str]:
 
 
 def get_caii_access_token() -> str:
-    if os.environ.get("CDP_TOKEN_OVERRIDE"):
-        return os.environ.get("CDP_TOKEN_OVERRIDE")
+    if os.environ["CDP_TOKEN_OVERRIDE"]:
+        return os.environ["CDP_TOKEN_OVERRIDE"]
 
     with open("/tmp/jwt", "r") as file:
         jwt_contents = json.load(file)

--- a/llm-service/app/services/caii/utils.py
+++ b/llm-service/app/services/caii/utils.py
@@ -36,6 +36,7 @@
 #  DATA.
 #
 import json
+import os
 from typing import Dict
 
 
@@ -46,6 +47,9 @@ def build_auth_headers() -> Dict[str, str]:
 
 
 def get_caii_access_token() -> str:
+    if os.environ.get("CDP_TOKEN_OVERRIDE"):
+        return os.environ.get("CDP_TOKEN_OVERRIDE")
+
     with open("/tmp/jwt", "r") as file:
         jwt_contents = json.load(file)
     access_token: str = jwt_contents["access_token"]

--- a/llm-service/app/services/caii/utils.py
+++ b/llm-service/app/services/caii/utils.py
@@ -47,8 +47,8 @@ def build_auth_headers() -> Dict[str, str]:
 
 
 def get_caii_access_token() -> str:
-    if os.environ["CDP_TOKEN_OVERRIDE"]:
-        return os.environ["CDP_TOKEN_OVERRIDE"]
+    if token_override := os.environ.get("CDP_TOKEN_OVERRIDE"):
+        return token_override
 
     with open("/tmp/jwt", "r") as file:
         jwt_contents = json.load(file)


### PR DESCRIPTION
What:

We're providing a new project environment variable for `CDP_TOKEN_OVERRIDE`.  

Why:

While the AMP can access the default token within a project, there may be cases where providing an override may be necessary.  For instance, if a user would like to point to a CAII environment other than the one they're currently in.

