### PR TITLE
Stream POC

### DIFF
--- a/llm-service/app/routers/index/sessions/__init__.py
+++ b/llm-service/app/routers/index/sessions/__init__.py
@@ -214,5 +214,11 @@ def stream_chat_completion(
                 {"text": response.message.content, "done": response.delta is None}
             ) + "\n"
 
+    try:
+        stream = generate_stream()
+    finally:
+        print("DONE")
+
+    # kick off evals with full response
     # todo: write to history, start evals, rewrite question, log to mlfow once the response is done
-    return StreamingResponse(generate_stream(), media_type="application/x-ndjson")
+    return StreamingResponse(stream, media_type="application/x-ndjson")

--- a/llm-service/app/routers/index/sessions/__init__.py
+++ b/llm-service/app/routers/index/sessions/__init__.py
@@ -46,7 +46,6 @@ from pydantic import BaseModel
 
 from .... import exceptions
 from ....rag_types import RagPredictConfiguration
-from ....services import models
 from ....services.chat import (
     v2_chat,
 )

--- a/llm-service/app/services/llm_completion.py
+++ b/llm-service/app/services/llm_completion.py
@@ -36,6 +36,7 @@
 #  DATA.
 #
 import itertools
+from typing import Generator
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -72,7 +73,7 @@ def completion(session_id: int, question: str, model_name: str) -> ChatResponse:
 
 def stream_completion(
     session_id: int, question: str, model_name: str
-) -> ChatResponseGen:
+) -> Generator[ChatResponse, None, None]:
     """
     Streamed version of the completion function.
     Returns a generator that yields ChatResponse objects as they become available.
@@ -85,7 +86,9 @@ def stream_completion(
         )
     )
     messages.append(ChatMessage.from_str(question, role="user"))
-    return model.stream_chat(messages)
+
+    stream = model.stream_chat(messages)
+    return stream
 
 
 def hypothetical(question: str, configuration: QueryConfiguration) -> str:

--- a/llm-service/app/services/llm_completion.py
+++ b/llm-service/app/services/llm_completion.py
@@ -36,14 +36,11 @@
 #  DATA.
 #
 import itertools
-from typing import Generator
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
     ChatResponseGen,
-    CompletionResponse,
-    CompletionResponseGen,
 )
 from llama_index.core.llms import LLM
 
@@ -98,18 +95,3 @@ def hypothetical(question: str, configuration: QueryConfiguration) -> str:
         "Produce a brief document that would hypothetically answer this question."
     )
     return model.complete(prompt).text
-
-
-def stream_hypothetical(
-    question: str, configuration: QueryConfiguration
-) -> CompletionResponseGen:
-    """
-    Streamed version of the hypothetical function.
-    Returns a generator that yields CompletionResponse objects as they become available.
-    """
-    model: LLM = models.LLM.get(configuration.model_name)
-    prompt: str = (
-        f"You are an expert. You are asked: {question}. "
-        "Produce a brief document that would hypothetically answer this question."
-    )
-    return model.stream_complete(prompt)

--- a/ui/src/api/utils.ts
+++ b/ui/src/api/utils.ts
@@ -80,6 +80,7 @@ export enum MutationKeys {
   "removeDataSourceFromProject" = "removeDataSourceFromProject",
   "updateAmpConfig" = "updateAmpConfig",
   "restartApplication" = "restartApplication",
+  "streamChatMutation" = "streamChatMutation",
 }
 
 export enum QueryKeys {

--- a/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
+++ b/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
@@ -40,11 +40,7 @@ import { Button, Flex, Input, InputRef, Switch, Tooltip } from "antd";
 import { DatabaseFilled, SendOutlined } from "@ant-design/icons";
 import { useContext, useEffect, useRef, useState } from "react";
 import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
-import {
-  createQueryConfiguration,
-  useChatMutation,
-  useStreamChatMutation,
-} from "src/api/chatApi.ts";
+import { createQueryConfiguration, useChatMutation } from "src/api/chatApi.ts";
 import { useParams, useSearch } from "@tanstack/react-router";
 import { cdlBlue600 } from "src/cuix/variables.ts";
 
@@ -66,7 +62,6 @@ const RagChatQueryInput = ({
 
   const [userInput, setUserInput] = useState("");
   const { sessionId } = useParams({ strict: false });
-  const [, setResponse] = useState("");
   const search: { question?: string } = useSearch({
     strict: false,
   });
@@ -90,12 +85,6 @@ const RagChatQueryInput = ({
     },
   });
 
-  const streamChatMutation = useStreamChatMutation({
-    onChunk: (chunk) => {
-      setResponse((prev) => prev + chunk);
-    },
-  });
-
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.focus();
@@ -108,7 +97,6 @@ const RagChatQueryInput = ({
     }
     if (userInput.length > 0) {
       if (sessionId) {
-        streamChatMutation.mutate({ query: userInput, sessionId: sessionId });
         chatMutation.mutate({
           query: userInput,
           session_id: +sessionId,

--- a/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
+++ b/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
@@ -40,7 +40,11 @@ import { Button, Flex, Input, InputRef, Switch, Tooltip } from "antd";
 import { DatabaseFilled, SendOutlined } from "@ant-design/icons";
 import { useContext, useEffect, useRef, useState } from "react";
 import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
-import { createQueryConfiguration, useChatMutation } from "src/api/chatApi.ts";
+import {
+  createQueryConfiguration,
+  useChatMutation,
+  useStreamChatMutation,
+} from "src/api/chatApi.ts";
 import { useParams, useSearch } from "@tanstack/react-router";
 import { cdlBlue600 } from "src/cuix/variables.ts";
 
@@ -62,11 +66,12 @@ const RagChatQueryInput = ({
 
   const [userInput, setUserInput] = useState("");
   const { sessionId } = useParams({ strict: false });
+  const [response, setResponse] = useState("");
   const search: { question?: string } = useSearch({
     strict: false,
   });
   const inputRef = useRef<InputRef>(null);
-
+  // console.log(response);
   const {
     data: sampleQuestions,
     isPending: sampleQuestionsIsPending,
@@ -85,6 +90,12 @@ const RagChatQueryInput = ({
     },
   });
 
+  const streamChatMutation = useStreamChatMutation({
+    onChunk: (chunk) => {
+      setResponse((prev) => prev + chunk);
+    },
+  });
+
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.focus();
@@ -97,6 +108,11 @@ const RagChatQueryInput = ({
     }
     if (userInput.length > 0) {
       if (sessionId) {
+        streamChatMutation.mutate({
+          query: userInput,
+          configuration: createQueryConfiguration(excludeKnowledgeBase),
+          session_id: +sessionId,
+        });
         chatMutation.mutate({
           query: userInput,
           session_id: +sessionId,

--- a/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
+++ b/ui/src/pages/RagChatTab/FooterComponents/RagChatQueryInput.tsx
@@ -40,7 +40,11 @@ import { Button, Flex, Input, InputRef, Switch, Tooltip } from "antd";
 import { DatabaseFilled, SendOutlined } from "@ant-design/icons";
 import { useContext, useEffect, useRef, useState } from "react";
 import { RagChatContext } from "pages/RagChatTab/State/RagChatContext.tsx";
-import { createQueryConfiguration, useChatMutation } from "src/api/chatApi.ts";
+import {
+  createQueryConfiguration,
+  useChatMutation,
+  useStreamChatMutation,
+} from "src/api/chatApi.ts";
 import { useParams, useSearch } from "@tanstack/react-router";
 import { cdlBlue600 } from "src/cuix/variables.ts";
 
@@ -62,6 +66,7 @@ const RagChatQueryInput = ({
 
   const [userInput, setUserInput] = useState("");
   const { sessionId } = useParams({ strict: false });
+  const [, setResponse] = useState("");
   const search: { question?: string } = useSearch({
     strict: false,
   });
@@ -85,6 +90,12 @@ const RagChatQueryInput = ({
     },
   });
 
+  const streamChatMutation = useStreamChatMutation({
+    onChunk: (chunk) => {
+      setResponse((prev) => prev + chunk);
+    },
+  });
+
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.focus();
@@ -97,6 +108,7 @@ const RagChatQueryInput = ({
     }
     if (userInput.length > 0) {
       if (sessionId) {
+        streamChatMutation.mutate({ query: userInput, sessionId: sessionId });
         chatMutation.mutate({
           query: userInput,
           session_id: +sessionId,


### PR DESCRIPTION
POC demonstrating using streaming responses against a direct llm call.  Additional work will be necessary to get this fully fleshed out to use.  Next steps include:

1. the Python side should kick off evals, question rewrites, etc after the streamed response is finished
2. The simple Python endpoint bypasses functionality for using the data source, which will need to be added
3. The UI will need to use the mutation 
4. Will need to add support for query config
5. Will need to replace the current loading chat UI with the streamed response
6. Once the streamed response is done, the UI will need to request the full payload.  