### PR TITLE
Fix Python logging alignment

### DIFF
--- a/llm-service/app/main.py
+++ b/llm-service/app/main.py
@@ -113,8 +113,8 @@ def _get_app_log_handler() -> logging.Handler:
         fmt=" ".join(
             [
                 "%(asctime)s",
-                "%(levelname)5s",
-                "%(name)30s",
+                "%(levelname)-7s",
+                "%(name)28s",
                 "%(message)s",
             ]
         )


### PR DESCRIPTION
### Before

```sh
00:18:26.623  INFO                     app.access received request "POST /chat/suggest-questions"
00:18:26.634  INFO         app.routers.index.chat THIS IS AN INFO
00:18:26.634 WARNING         app.routers.index.chat THIS IS A WARNING
00:19:08.288  INFO                 uvicorn.access 127.0.0.1:62568 - "POST /chat/suggest-questions HTTP/1.1" 200
```

### After

```sh
00:25:31.763  INFO                      app.access received request "POST /chat/suggest-questions"
00:25:31.765  INFO          app.routers.index.chat THIS IS AN INFO
00:25:31.766  WARNING       app.routers.index.chat THIS IS A WARNING
00:26:09.662  INFO                  uvicorn.access 127.0.0.1:62894 - "POST /chat/suggest-questions HTTP/1.1" 200
```