### PR TITLE
Pin version of opensearch and add note in UI

### DIFF
--- a/local-dev.sh
+++ b/local-dev.sh
@@ -126,6 +126,7 @@ cd ../backend
 
 # start frontend development server
 cd ../ui
+rm -rf node_modules
 pnpm install
 pnpm build
 pnpm dev &

--- a/opensearch/docker-compose.yaml
+++ b/opensearch/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
-    image: opensearchproject/opensearch:latest # Specifying the latest available image - modify if you want a specific version
+    image: opensearchproject/opensearch:2.19.3 # Specifying the latest available image - modify if you want a specific version
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster # Name the cluster
@@ -26,7 +26,7 @@ services:
     networks:
       - opensearch-net # All of the containers will join the same Docker bridge network
   opensearch-node2:
-    image: opensearchproject/opensearch:latest # This should be the same image used for opensearch-node1 to avoid issues
+    image: opensearchproject/opensearch:2.19.3 # This should be the same image used for opensearch-node1 to avoid issues
     container_name: opensearch-node2
     environment:
       - cluster.name=opensearch-cluster
@@ -49,7 +49,7 @@ services:
     networks:
       - opensearch-net
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:latest # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
+    image: opensearchproject/opensearch-dashboards:2.19.3 # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
     container_name: opensearch-dashboards
     ports:
       - 5601:5601 # Map host port 5601 to container port 5601

--- a/ui/src/pages/Settings/VectorDBFields.tsx
+++ b/ui/src/pages/Settings/VectorDBFields.tsx
@@ -69,6 +69,11 @@ export const VectorDBFields = ({
         Embedded Qdrant will be used as the vector database.
       </StyledHelperText>
     )}
+    {selectedVectorDBProvider === "OPENSEARCH" ? (
+      <StyledHelperText>
+        We currently support OpenSearch versions up to and including 2.19.3
+      </StyledHelperText>
+    ) : null}
     <Form.Item
       label={"OpenSearch Endpoint"}
       initialValue={projectConfig?.opensearch_config.opensearch_endpoint}


### PR DESCRIPTION
* Pin version of OpenSearch to 2.19.3 when running locally via docker compose
* Add note to UI to note that we only support up to and including 2.19.3
* Delete node_modules when starting up locally to address old chunks throwing errors

<img width="646" height="361" alt="Screenshot 2025-08-21 at 11 39 43 AM" src="https://github.com/user-attachments/assets/fd44c32e-b5dc-40f5-afaf-e975821e5fb2" />
