### PR TITLE
Set indexing error when embedding model returns incorrect number of embeddings

### DIFF
--- a/llm-service/app/ai/indexing/embedding_indexer.py
+++ b/llm-service/app/ai/indexing/embedding_indexer.py
@@ -133,7 +133,8 @@ class EmbeddingIndexer(BaseTextIndexer):
                 batch_chunks = batched_chunks[i]
                 if len(batch_chunks) != len(batch_embeddings):
                     raise ValueError(
-                        f"Expected {len(batch_chunks)} embedding vectors, but got {len(batch_embeddings)}"
+                        f"Expected {len(batch_chunks)} embedding vectors for this batch of chunks,"
+                        + f" but got {len(batch_embeddings)} from {self.embedding_model.model_name}"
                     )
                 for chunk, embedding in zip(batch_chunks, batch_embeddings):
                     chunk.embedding = embedding


### PR DESCRIPTION
Currently, if an embedding model somehow returns fewer embedding vectors than expected for a batched chunk, this `zip()`

https://github.com/cloudera/CML_AMP_RAG_Studio/blob/690c19c2275524bbe392bda13a77577884bd337a/llm-service/app/ai/indexing/embedding_indexer.py#L139-L140

will silently truncate, leaving chunks without embeddings and subsequently throw an enigmatic `ValueError: embedding not set` from LlamaIndex when adding the chunks to the vector store.

---

After this change, we (and the UI) will have this explicit error:

```
indexingStatus=ERROR,
indexingError=Expected 70 embedding vectors for this batch of chunks, but got 1 from cohere.embed-english-v3
```

<img width="412" height="152" alt="Screenshot 2025-09-19 at 2 38 04 PM" src="https://github.com/user-attachments/assets/c94d2a3d-3118-4d64-83fa-d40f8a39186f" />
