### PR TITLE
fix: handle blank strings in env variables for CSS and ChromaDB

### DIFF
--- a/llm-service/app/config.py
+++ b/llm-service/app/config.py
@@ -129,6 +129,9 @@ class _Settings:
 
     @property
     def opensearch_namespace(self) -> str:
+        # handle case where OPENSEARCH_NAMESPACE is blank string
+        if not os.environ.get("OPENSEARCH_NAMESPACE"):
+            return "rag_document_index"
         return os.environ.get("OPENSEARCH_NAMESPACE", "rag_document_index")
 
     @property
@@ -163,10 +166,16 @@ class _Settings:
 
     @property
     def chromadb_tenant(self) -> str:
+        # handle case where CHROMADB_TENANT is blank string
+        if not os.environ.get("CHROMADB_TENANT"):
+            return DEFAULT_TENANT
         return os.environ.get("CHROMADB_TENANT", DEFAULT_TENANT)
 
     @property
     def chromadb_database(self) -> str:
+        # handle case where CHROMADB_DATABASE is blank string
+        if not os.environ.get("CHROMADB_DATABASE"):
+            return DEFAULT_DATABASE
         return os.environ.get("CHROMADB_DATABASE", DEFAULT_DATABASE)
 
     @property


### PR DESCRIPTION
This change fixes 

```
2025-09-22 22:00:24,683 - ERROR - Encountered internal error
Traceback (most recent call last):
  File "/home/cdsw/llm-service/app/exceptions.py", line 74, in _exception_propagation
    yield
  File "/home/cdsw/llm-service/app/exceptions.py", line 139, in exception_propagation_wrapper
    return f(*args, **kwargs)
  File "/home/cdsw/llm-service/app/routers/index/data_source/__init__.py", line 253, in summarize_document
    indexer.index_file(file_path, doc_id)
  File "/home/cdsw/llm-service/app/ai/indexing/summary_indexer.py", line 298, in index_file
    summary_store: DocumentSummaryIndex = self.__summary_indexer(persist_dir)
  File "/home/cdsw/llm-service/app/ai/indexing/summary_indexer.py", line 179, in __summary_indexer
  ....
    return f(*args, **kwargs)
  File "/home/cdsw/llm-service/.venv/lib/python3.10/site-packages/chromadb/api/fastapi.py", line 255, in create_collection
    resp_json = self._make_request(
  File "/home/cdsw/llm-service/.venv/lib/python3.10/site-packages/chromadb/api/fastapi.py", line 108, in _make_request
    BaseHTTPClient._raise_chroma_error(response)
  File "/home/cdsw/llm-service/.venv/lib/python3.10/site-packages/chromadb/api/base_http_client.py", line 97, in _raise_chroma_error
    raise chroma_error
chromadb.errors.InvalidArgumentError: Validation error: name: Expected a name containing 3-512 characters from [a-zA-Z0-9._-], starting and ending with a character in [a-zA-Z0-9]. Got: ____summary_index_33
```